### PR TITLE
Cross-workspace correctness fixes and lint cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Root .dockerignore — applies ONLY to root-context image builds. Currently that
+# is the taskforge image (.github/workflows/taskforge.yml uses `context: .`).
+# The nginxpilot image keeps `context: nginxpilot` + its own .dockerignore, so it
+# is unaffected by this file.
+
+# version control / CI
+.git
+.github
+
+# all workspace dependencies + build outputs — reinstalled/rebuilt inside the image.
+# NOTE: only the published packages' build dirs are listed; taskforge/lib is SOURCE
+# (the @/lib/* modal+toast helpers) and must NOT be ignored.
+**/node_modules
+base/lib
+logging/lib
+serializer/lib
+web-components/lib
+phaser-plus/lib
+node/lib
+examples/dist
+**/.next
+**/*.tsbuildinfo
+
+# taskforge runtime state & secrets — MUST never enter the image
+taskforge/.workspace
+taskforge/.claude-accounts
+**/taskforge.db
+**/taskforge.db-*
+**/*.db-wal
+**/*.db-shm
+
+# env / secrets
+**/.env
+**/.env*.local
+
+# misc noise
+**/npm-debug.log*
+**/.DS_Store

--- a/.github/workflows/taskforge.yml
+++ b/.github/workflows/taskforge.yml
@@ -3,9 +3,23 @@ name: taskforge
 on:
   push:
     branches: [main]
-    paths: ['taskforge/**', '.github/workflows/taskforge.yml']
+    # the image bundles built @toolcase/base + web-components, so changes there
+    # must rebuild taskforge too (build context is the repo root).
+    paths:
+      - 'taskforge/**'
+      - 'base/**'
+      - 'web-components/**'
+      - 'package-lock.json'
+      - '.dockerignore'
+      - '.github/workflows/taskforge.yml'
   pull_request:
-    paths: ['taskforge/**', '.github/workflows/taskforge.yml']
+    paths:
+      - 'taskforge/**'
+      - 'base/**'
+      - 'web-components/**'
+      - 'package-lock.json'
+      - '.dockerignore'
+      - '.github/workflows/taskforge.yml'
 
 permissions:
   contents: read
@@ -44,7 +58,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: taskforge
+          # repo root: taskforge's @toolcase/* deps are file:../ workspace
+          # siblings, so the build needs the whole monorepo (see taskforge/Dockerfile).
+          context: .
+          file: taskforge/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 lib
+# taskforge uses lib/ as a SOURCE dir (Next.js app helpers), not build output — keep it tracked
+!taskforge/lib/
 node_modules
 .parcel-cache
 .DS_Store

--- a/base/src/BPlusIndex/BPlusIndex.ts
+++ b/base/src/BPlusIndex/BPlusIndex.ts
@@ -69,7 +69,10 @@ export class BPlusIndex<K, V> {
 
     static deserializers = {
         string:     (b: Uint8Array): string => DEC.decode(b),
-        number:     (b: Uint8Array): number => new DataView(b.buffer, b.byteOffset, b.byteLength).getFloat64(0, true),
+        number:     (b: Uint8Array): number => {
+            const v = new DataView(b.buffer, b.byteOffset, b.byteLength).getFloat64(0, true)
+            return Object.is(v, -0) ? 0 : v   // normalize negative zero to +0
+        },
         bigint:     (b: Uint8Array): bigint => {
             const view  = new DataView(b.buffer, b.byteOffset, b.byteLength)
             const magLen = view.getUint16(0, true)
@@ -838,38 +841,35 @@ export class BPlusIndex<K, V> {
             const hasLower = gte !== undefined || gt !== undefined
             const lowerKey = gte ?? gt
 
+            // Leaf IDs in ascending key order via authoritative tree descent;
+            // the `nextPageId` sibling chain is not trustworthy after COW.
+            const leafIds = await this._collectAllLeafIds()
+
             if (hasLower) {
+                // Locate the leaf that should contain the lower bound, then scan
+                // it and every subsequent leaf in order.
                 const { leaf } = await this._findLeaf(lowerKey!)
+                const startLeafIdx = leafIds.indexOf(leaf.pageId)
                 const pos = this._lowerBound(leaf.entries.map(e => e.keyRaw), lowerKey!)
-                let startIdx = pos
-                if (gt !== undefined && startIdx < leaf.entries.length) {
-                    if (this.compare(this.deserializeKey(leaf.entries[startIdx].keyRaw), gt) === 0) startIdx++
+                let startEntry = pos
+                if (gt !== undefined && startEntry < leaf.entries.length) {
+                    if (this.compare(this.deserializeKey(leaf.entries[startEntry].keyRaw), gt) === 0) startEntry++
                 }
 
-                for (let i = startIdx; i < leaf.entries.length; i++) {
-                    const k = this.deserializeKey(leaf.entries[i].keyRaw)
-                    if (lte !== undefined && this.compare(k, lte) > 0) return
-                    if (lt  !== undefined && this.compare(k, lt)  >= 0) return
-                    yield [k, this.deserializeValue(leaf.entries[i].valueRaw)]
-                    if (++yielded === limit) return
-                }
-
-                let nextId = leaf.nextPageId
-                while (nextId !== NULL_PAGE) {
-                    const nl = await this._readLeaf(nextId)
-                    for (const e of nl.entries) {
-                        const k = this.deserializeKey(e.keyRaw)
+                for (let li = Math.max(startLeafIdx, 0); li < leafIds.length; li++) {
+                    const cur = li === startLeafIdx ? leaf : await this._readLeaf(leafIds[li])
+                    const from = li === startLeafIdx ? startEntry : 0
+                    for (let i = from; i < cur.entries.length; i++) {
+                        const k = this.deserializeKey(cur.entries[i].keyRaw)
                         if (lte !== undefined && this.compare(k, lte) > 0) return
                         if (lt  !== undefined && this.compare(k, lt)  >= 0) return
-                        yield [k, this.deserializeValue(e.valueRaw)]
+                        yield [k, this.deserializeValue(cur.entries[i].valueRaw)]
                         if (++yielded === limit) return
                     }
-                    nextId = nl.nextPageId
                 }
             } else {
-                // Full scan from leftmost leaf
-                let pageId = await this._leftmostLeafId()
-                while (pageId !== NULL_PAGE) {
+                // Full scan in ascending leaf order
+                for (const pageId of leafIds) {
                     const leaf = await this._readLeaf(pageId)
                     for (const e of leaf.entries) {
                         const k = this.deserializeKey(e.keyRaw)
@@ -878,12 +878,11 @@ export class BPlusIndex<K, V> {
                         yield [k, this.deserializeValue(e.valueRaw)]
                         if (++yielded === limit) return
                     }
-                    pageId = leaf.nextPageId
                 }
             }
         } else {
             // ── reverse scan ─────────────────────────────────────────────────
-            // Collect all leaf IDs by forward scan (avoids stale prevPageId links)
+            // Collect all leaf IDs via tree descent (avoids stale prev/next links)
             const leafIds = await this._collectAllLeafIds()
             for (let li = leafIds.length - 1; li >= 0; li--) {
                 const leaf = await this._readLeaf(leafIds[li])
@@ -900,24 +899,29 @@ export class BPlusIndex<K, V> {
         }
     }
 
-    private async _leftmostLeafId(): Promise<number> {
-        let pageId = this.rootPageId
-        while (true) {
-            const raw = await this.adapter.read(pageId)
-            if (!raw || raw[4] === PAGE_TYPE_LEAF) return pageId
-            const node = await this._readInternal(pageId)
-            pageId = node.children[0]
-        }
-    }
-
+    /**
+     * Gather every leaf page ID in ascending key order by descending the tree
+     * via internal-node children (which are kept authoritative on every COW
+     * split/update).  The leaf `nextPageId` sibling chain is NOT used: a leaf
+     * that is copied or split is relocated to a fresh page and freed, but its
+     * left sibling's `nextPageId` is intentionally not rewritten (see
+     * `_splitLeaf`), so that chain can dangle to a freed/reused page.
+     */
     private async _collectAllLeafIds(): Promise<number[]> {
         const ids: number[] = []
-        let pageId = await this._leftmostLeafId()
-        while (pageId !== NULL_PAGE) {
-            ids.push(pageId)
-            const leaf = await this._readLeaf(pageId)
-            pageId = leaf.nextPageId
+
+        const descend = async (pageId: number): Promise<void> => {
+            const raw = await this.adapter.read(pageId)
+            if (!raw) throw new Error(`BPlusIndex: missing page ${pageId}`)
+            if (raw[4] === PAGE_TYPE_LEAF) {
+                ids.push(pageId)
+                return
+            }
+            const node = await this._readInternal(pageId)
+            for (const childId of node.children) await descend(childId)
         }
+
+        await descend(this.rootPageId)
         return ids
     }
 

--- a/base/src/Vec2.ts
+++ b/base/src/Vec2.ts
@@ -65,7 +65,7 @@ class Vec2 {
     }
 
     negate(): Vec2 {
-        return new Vec2(-this.x, -this.y)
+        return new Vec2(this.x === 0 ? 0 : -this.x, this.y === 0 ? 0 : -this.y)
     }
 
     distanceTo(other: Vec2): number {

--- a/base/src/async/throttle.ts
+++ b/base/src/async/throttle.ts
@@ -18,6 +18,7 @@ function throttle<T extends ThrottleFn>(fn: T, ms: number): ThrottledFn<T> {
         const now = Date.now()
         const remaining = ms - (now - lastCall)
         lastArgs = args
+        // eslint-disable-next-line @typescript-eslint/no-this-alias -- preserve caller context for deferred apply()
         lastCtx = this
 
         if (remaining <= 0 || remaining > ms) {

--- a/base/src/formatByteSize.ts
+++ b/base/src/formatByteSize.ts
@@ -1,5 +1,5 @@
 const formatByteSize = (bytes: number, decimals: number = 2): string => {
-    if (!Number.isFinite(bytes) || bytes <= 0) return '0 Bytes'
+    if (!Number.isFinite(bytes) || bytes < 1) return '0 Bytes'
     const k = 1024
     const dm = decimals < 0 ? 0 : decimals
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']

--- a/base/src/packing/MaxRects.ts
+++ b/base/src/packing/MaxRects.ts
@@ -82,8 +82,8 @@ class MaxRects extends Algorithm {
         const shortLeftover = Math.min(leftoverHorizontal, leftoverVertical)
         const longLeftover = Math.max(leftoverHorizontal, leftoverVertical)
 
-        let score1 = 0
-        let score2 = 0
+        let score1: number
+        let score2: number
         switch (this.heuristic) {
             case 'best-short-side-fit':
                 score1 = shortLeftover

--- a/base/src/slugify.ts
+++ b/base/src/slugify.ts
@@ -4,7 +4,7 @@ function slugify(input: string): string {
         .toLowerCase()
         .normalize('NFD')
         .replace(/[̀-ͯ]/g, '')
-        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/[^a-z0-9\s_-]/g, '')
         .replace(/[\s_-]+/g, '-')
         .replace(/^-+|-+$/g, '')
 }

--- a/base/src/spatial/SpatialHash.ts
+++ b/base/src/spatial/SpatialHash.ts
@@ -98,6 +98,7 @@ class SpatialHash<T> {
     }
 
     nearest(point: SpatialPoint, maxDist = Infinity): T | null {
+        if (this._size === 0) return null
         const { cs } = this
         const cx0 = Math.floor(point.x / cs)
         const cy0 = Math.floor(point.y / cs)
@@ -105,7 +106,9 @@ class SpatialHash<T> {
         let bestDist = maxDist
         const seen = new Set<T>()
         for (let r = 0; r <= 1e4; r++) {
-            if (best !== null && (r - 1) * cs >= bestDist) break
+            // Once the nearest cell edge in this ring is beyond the best distance
+            // found so far (or the maxDist cap), no closer item can exist.
+            if ((r - 1) * cs >= bestDist) break
             if (r === 0) {
                 this.scanCell(cx0, cy0, point, seen, (item, d) => {
                     if (d < bestDist) { bestDist = d; best = item }

--- a/base/test/BPlusIndex.test.ts
+++ b/base/test/BPlusIndex.test.ts
@@ -287,7 +287,7 @@ describe('BPlusIndex — comparators / serializers round-trip', () => {
     it('number round-trips', () => {
         for (const n of [0, -1, 1.5, Math.PI, Number.MAX_SAFE_INTEGER, -0]) {
             const b = BPlusIndex.serializers.number(n)
-            expect(BPlusIndex.deserializers.number(b)).toBe(n === -0 ? 0 : n)
+            expect(BPlusIndex.deserializers.number(b)).toBe(Object.is(n, -0) ? 0 : n)
         }
     })
 

--- a/base/test/Color.test.ts
+++ b/base/test/Color.test.ts
@@ -75,10 +75,11 @@ describe('Color — WCAG contrast utilities', () => {
             expect(Color.luminance('#000000')).toBeCloseTo(0.0, 5)
         })
 
-        it('mid-grey #767676 has luminance ~0.2158', () => {
-            // WCAG reference: relative luminance of #767676 ≈ 0.2158
-            // linearC ≈ 0.2158 for equal R, G, B channels at 118/255
-            expect(Color.luminance('#767676')).toBeCloseTo(0.2158, 3)
+        it('mid-grey #767676 has luminance ~0.1812', () => {
+            // WCAG reference: relative luminance of #767676 ≈ 0.1812
+            // 118/255 = 0.46275 → linearized = ((0.46275 + 0.055) / 1.055)^2.4 ≈ 0.1812
+            // (equal R, G, B channels, so luminance == the linearized channel value)
+            expect(Color.luminance('#767676')).toBeCloseTo(0.1812, 3)
         })
 
         it('accepts 3-digit shorthand hex', () => {

--- a/base/test/DisjointSet.test.ts
+++ b/base/test/DisjointSet.test.ts
@@ -129,7 +129,8 @@ describe('DisjointSet', () => {
         ds.union('2', '3')
         ds.union('4', '5')
         ds.union('0', '2')
-        expect(ds.count).toBe(7)
+        // 10 singletons, 4 distinct-root unions → 6 components: {0,1,2,3},{4,5},{6},{7},{8},{9}
+        expect(ds.count).toBe(6)
         expect(ds.connected('0', '3')).toBe(true)
         expect(ds.connected('0', '4')).toBe(false)
         expect(ds.connected('6', '7')).toBe(false)

--- a/base/test/PageCache.test.ts
+++ b/base/test/PageCache.test.ts
@@ -174,12 +174,12 @@ describe('PageCache — LRU eviction', () => {
         await cache.read(3)
         expect(spy.readCount).toBe(1)
 
-        // Page 2 was evicted
-        await cache.read(2)
-        expect(spy.readCount).toBe(2)
-
-        // Page 1 is still cached
+        // Page 1 was refreshed by the touch, so it survived eviction → still cached
         await cache.read(1)
+        expect(spy.readCount).toBe(1)
+
+        // Page 2 was the LRU victim → no longer cached
+        await cache.read(2)
         expect(spy.readCount).toBe(2)
     })
 })
@@ -268,18 +268,26 @@ describe('PageCache + FsAdapter — transparent composition', () => {
 
     it('cache reduces adapter reads on repeated lookups', async () => {
         const spy = new SpyAdapter()
-        const cache = new PageCache(spy, 32)
 
+        // Build the data. The write-through cache used while writing warms itself,
+        // so to measure a genuine cold→hot transition we reopen with a fresh
+        // (cold) cache over the same underlying storage for the read passes.
+        const writer = await BPlusIndex.open<string, string>({
+            ...strOpts,
+            adapter: new PageCache(spy, 32),
+        })
+        for (let i = 0; i < 10; i++) {
+            await writer.set(`k${i}`, `v${i}`)
+        }
+        await writer.close()
+
+        const cache = new PageCache(spy, 32)
         const idx = await BPlusIndex.open<string, string>({
             ...strOpts,
             adapter: cache,
         })
 
-        for (let i = 0; i < 10; i++) {
-            await idx.set(`k${i}`, `v${i}`)
-        }
-
-        // First pass: cold reads
+        // First pass: cold reads (fresh cache must fetch pages from the adapter)
         spy.readCount = 0
         for (let i = 0; i < 10; i++) {
             await idx.get(`k${i}`)
@@ -293,6 +301,7 @@ describe('PageCache + FsAdapter — transparent composition', () => {
         }
         const hotReads = spy.readCount
 
+        expect(coldReads).toBeGreaterThan(0)
         expect(hotReads).toBeLessThan(coldReads)
     })
 })

--- a/base/test/Stopwatch.test.ts
+++ b/base/test/Stopwatch.test.ts
@@ -9,7 +9,7 @@ describe('Stopwatch', () => {
     })
 
     it('starts not running with zero elapsed', () => {
-        let t = 0
+        const t = 0
         const sw = new Stopwatch(() => t)
         expect(sw.running).toBe(false)
         expect(sw.elapsed).toBe(0)
@@ -47,7 +47,7 @@ describe('Stopwatch', () => {
     })
 
     it('stop is a no-op when not running', () => {
-        let t = 0
+        const t = 0
         const sw = new Stopwatch(() => t)
         sw.stop()
         expect(sw.elapsed).toBe(0)
@@ -125,7 +125,7 @@ describe('Stopwatch', () => {
     })
 
     it('start, stop, reset all return this', () => {
-        let t = 0
+        const t = 0
         const sw = new Stopwatch(() => t)
         expect(sw.start()).toBe(sw)
         expect(sw.stop()).toBe(sw)

--- a/base/test/TokenBucket.test.ts
+++ b/base/test/TokenBucket.test.ts
@@ -35,7 +35,7 @@ describe('TokenBucket', () => {
     })
 
     it('starts full at capacity', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(10, 1, () => t)
         expect(bucket.tokens).toBe(10)
         expect(bucket.capacity).toBe(10)
@@ -43,14 +43,14 @@ describe('TokenBucket', () => {
     })
 
     it('removes tokens when sufficient', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(10, 1, () => t)
         expect(bucket.tryRemove(3)).toBe(true)
         expect(bucket.tokens).toBe(7)
     })
 
     it('returns false when not enough tokens', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(5, 1, () => t)
         expect(bucket.tryRemove(6)).toBe(false)
         expect(bucket.tokens).toBe(5)
@@ -88,7 +88,7 @@ describe('TokenBucket', () => {
     })
 
     it('take is an alias for tryRemove', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(10, 1, () => t)
         expect(bucket.take(4)).toBe(true)
         expect(bucket.tokens).toBe(6)
@@ -97,14 +97,14 @@ describe('TokenBucket', () => {
     })
 
     it('tryRemove defaults n to 1', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(5, 1, () => t)
         expect(bucket.tryRemove()).toBe(true)
         expect(bucket.tokens).toBe(4)
     })
 
     it('take defaults n to 1', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(5, 1, () => t)
         expect(bucket.take()).toBe(true)
         expect(bucket.tokens).toBe(4)
@@ -132,7 +132,7 @@ describe('TokenBucket', () => {
     })
 
     it('allows removing all tokens exactly', () => {
-        let t = 0
+        const t = 0
         const bucket = new TokenBucket(7, 1, () => t)
         expect(bucket.tryRemove(7)).toBe(true)
         expect(bucket.tokens).toBe(0)

--- a/base/test/async/withTimeout.test.ts
+++ b/base/test/async/withTimeout.test.ts
@@ -26,14 +26,16 @@ describe('withTimeout', () => {
     it('rejects with a timeout error when fn takes too long', async () => {
         const slow = () => new Promise<void>(resolve => setTimeout(resolve, 500))
         const p = withTimeout(slow, 100)
+        const assertion = expect(p).rejects.toThrow('timed out after 100ms')
         await vi.advanceTimersByTimeAsync(200)
-        await expect(p).rejects.toThrow('timed out after 100ms')
+        await assertion
     })
 
     it('propagates fn rejection before timeout', async () => {
         const p = withTimeout(() => Promise.reject(new Error('nope')), 100)
+        const assertion = expect(p).rejects.toThrow('nope')
         await vi.runAllTimersAsync()
-        await expect(p).rejects.toThrow('nope')
+        await assertion
     })
 
     it('composes with retry — retries on timeout', async () => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,12 +34,21 @@ export default tseslint.config(
         },
     },
     {
-        files: ['scripts/**'],
+        files: ['**/scripts/**'],
         languageOptions: {
             globals: {
                 console: 'readonly',
                 process: 'readonly',
             },
+        },
+    },
+    {
+        // Generated JSX typings: module/global augmentation of React.JSX requires
+        // `namespace` and empty `interface … extends …` — both unavoidable here.
+        files: ['**/react-types.ts'],
+        rules: {
+            '@typescript-eslint/no-namespace': 'off',
+            '@typescript-eslint/no-empty-object-type': 'off',
         },
     },
 )

--- a/logging/src/BeaconReporter.ts
+++ b/logging/src/BeaconReporter.ts
@@ -45,18 +45,17 @@ class BeaconReporter extends LogReporter {
     }
 
     private installErrorHandlers(): void {
-        const self = this
         if (typeof window === 'undefined') return
         const prevOnError = typeof window.onerror === 'function' ? window.onerror : null
-        window.onerror = function (message, source, lineno, colno, error) {
+        window.onerror = (message, source, lineno, colno, error) => {
             const msg = error ?? (typeof message === 'string' ? message : String(message))
-            self.log('error', self.errorScope, Date.now(), {}, [msg, { source, lineno, colno }])
+            this.log('error', this.errorScope, Date.now(), {}, [msg, { source, lineno, colno }])
             if (prevOnError) return (prevOnError as any)(message, source, lineno, colno, error)
             return false
         }
         window.addEventListener('unhandledrejection', (evt: PromiseRejectionEvent) => {
             const reason = evt.reason instanceof Error ? evt.reason : { reason: evt.reason }
-            self.log('error', self.errorScope, Date.now(), {}, ['Unhandled promise rejection', reason])
+            this.log('error', this.errorScope, Date.now(), {}, ['Unhandled promise rejection', reason])
         })
     }
 

--- a/logging/src/FileLogReporter.ts
+++ b/logging/src/FileLogReporter.ts
@@ -33,11 +33,11 @@ class FileLogReporter extends StreamReporter {
     }
 
     private shiftFiles(): void {
-        try { unlinkSync(`${this.filePath}.${this.maxFiles}`) } catch {}
+        try { unlinkSync(`${this.filePath}.${this.maxFiles}`) } catch { /* file may not exist */ }
         for (let i = this.maxFiles - 1; i >= 1; i--) {
-            try { renameSync(`${this.filePath}.${i}`, `${this.filePath}.${i + 1}`) } catch {}
+            try { renameSync(`${this.filePath}.${i}`, `${this.filePath}.${i + 1}`) } catch { /* file may not exist */ }
         }
-        try { renameSync(this.filePath, `${this.filePath}.1`) } catch {}
+        try { renameSync(this.filePath, `${this.filePath}.1`) } catch { /* file may not exist */ }
     }
 
 }

--- a/logging/src/Formatter.ts
+++ b/logging/src/Formatter.ts
@@ -45,7 +45,7 @@ export const jsonFormatter: LogFormatter = (level, scope, time, fields, messages
 
 function logfmtEscape(v: string): string {
     if (v === '') return '""'
-    if (/[\s"=]/.test(v)) return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+    if (/[\s"=]/.test(v)) return `"${v}"`
     return v
 }
 

--- a/logging/src/StreamReporter.ts
+++ b/logging/src/StreamReporter.ts
@@ -44,7 +44,7 @@ class StreamReporter extends LogReporter {
 
     private writeLine(line: string): void {
         const lineBytes = Buffer.byteLength(line)
-        if (this.maxBytes > 0 && this.bytesWritten + lineBytes > this.maxBytes) {
+        if (this.maxBytes > 0 && this.bytesWritten > 0 && this.bytesWritten + lineBytes >= this.maxBytes) {
             this.pending.push(line)
             this.rotate()
             return

--- a/logging/src/node.ts
+++ b/logging/src/node.ts
@@ -5,3 +5,5 @@ import ContextualReporter from './ContextualReporter'
 
 export { StreamReporter, FileLogReporter, defaultStreamFormatter, AsyncContext, ContextualReporter }
 export type { StreamLogFormatter, StreamReporterOptions, FileLogFormatter, FileLogReporterOptions }
+
+export default FileLogReporter

--- a/logging/test/logging.test.ts
+++ b/logging/test/logging.test.ts
@@ -2793,20 +2793,27 @@ function makeFakeIDB() {
 
 describe('BeaconReporter', () => {
 
+    // On Node 21+ `globalThis.navigator` is a getter-only accessor, so a plain
+    // assignment throws "Cannot set property navigator ... which has only a getter".
+    // Define it as a configurable/writable property so tests can stub and restore it.
+    const setNavigator = (value: any) => {
+        Object.defineProperty(globalThis, 'navigator', { value, configurable: true, writable: true })
+    }
+
     it('throws when navigator.sendBeacon is absent', () => {
         const orig = (globalThis as any).navigator
-        ;(globalThis as any).navigator = undefined
+        setNavigator(undefined)
         try {
             expect(() => new BeaconReporter({ url: '/logs' })).toThrow('navigator.sendBeacon')
         } finally {
-            ;(globalThis as any).navigator = orig
+            setNavigator(orig)
         }
     })
 
     it('buffers entries and sends them via sendBeacon on flush', () => {
         const orig = (globalThis as any).navigator
         const calls: { url: string; data: string }[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (url: string, data: string) => { calls.push({ url, data }); return true } }
+        setNavigator({ sendBeacon: (url: string, data: string) => { calls.push({ url, data }); return true } })
         try {
             const reporter = new BeaconReporter({ url: '/logs', maxSize: 100, flushInterval: 0 })
             reporter.log('info', 'svc', T0, {}, ['hello'])
@@ -2819,14 +2826,14 @@ describe('BeaconReporter', () => {
             expect(entries[0].level).toBe('info')
             expect(entries[1].level).toBe('warning')
         } finally {
-            ;(globalThis as any).navigator = orig
+            setNavigator(orig)
         }
     })
 
     it('each entry carries level, scope, time, fields, and messages', () => {
         const orig = (globalThis as any).navigator
         const calls: any[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { calls.push(JSON.parse(data)); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { calls.push(JSON.parse(data)); return true } })
         try {
             const reporter = new BeaconReporter({ url: '/logs', maxSize: 1, flushInterval: 0 })
             reporter.log('error', 'auth', T0, { reqId: 'r1' }, ['boom', { code: 42 }])
@@ -2837,7 +2844,7 @@ describe('BeaconReporter', () => {
             expect(entry.fields).toEqual({ reqId: 'r1' })
             expect(entry.messages).toEqual(['boom', { code: 42 }])
         } finally {
-            ;(globalThis as any).navigator = orig
+            setNavigator(orig)
         }
     })
 
@@ -2846,7 +2853,7 @@ describe('BeaconReporter', () => {
         const origWin = (globalThis as any).window
         const beaconCalls: string[] = []
         const pageHideListeners: Array<() => void> = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { beaconCalls.push(data); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { beaconCalls.push(data); return true } })
         ;(globalThis as any).window = {
             onerror: null,
             addEventListener: (event: string, fn: () => void, _opts?: any) => {
@@ -2861,26 +2868,26 @@ describe('BeaconReporter', () => {
             const entries = JSON.parse(beaconCalls[0])
             expect(entries[0].messages[0]).toBe('critical')
         } finally {
-            ;(globalThis as any).navigator = origNav
+            setNavigator(origNav)
             ;(globalThis as any).window = origWin
         }
     })
 
     it('does not throw when sendBeacon throws', () => {
         const orig = (globalThis as any).navigator
-        ;(globalThis as any).navigator = { sendBeacon: () => { throw new Error('beacon failed') } }
+        setNavigator({ sendBeacon: () => { throw new Error('beacon failed') } })
         try {
             const reporter = new BeaconReporter({ url: '/logs', maxSize: 1, flushInterval: 0 })
             expect(() => reporter.log('error', 's', T0, {}, ['msg'])).not.toThrow()
         } finally {
-            ;(globalThis as any).navigator = orig
+            setNavigator(orig)
         }
     })
 
     it('respects factory level filtering', () => {
         const orig = (globalThis as any).navigator
         const calls: any[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { calls.push(JSON.parse(data)); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { calls.push(JSON.parse(data)); return true } })
         try {
             const reporter = new BeaconReporter({ url: '/logs', maxSize: 10, flushInterval: 0 })
             const factory = new LoggerFactory([reporter])
@@ -2893,7 +2900,7 @@ describe('BeaconReporter', () => {
             expect(calls[0]).toHaveLength(1)
             expect(calls[0][0].level).toBe('warning')
         } finally {
-            ;(globalThis as any).navigator = orig
+            setNavigator(orig)
         }
     })
 
@@ -2901,7 +2908,7 @@ describe('BeaconReporter', () => {
         const origNav = (globalThis as any).navigator
         const origWin = (globalThis as any).window
         const beaconCalls: any[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { beaconCalls.push(JSON.parse(data)); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { beaconCalls.push(JSON.parse(data)); return true } })
         const mockWindow: any = { onerror: null, addEventListener: () => {} }
         ;(globalThis as any).window = mockWindow
         try {
@@ -2911,7 +2918,7 @@ describe('BeaconReporter', () => {
             expect(beaconCalls[0][0].level).toBe('error')
             expect(beaconCalls[0][0].scope).toBe('window')
         } finally {
-            ;(globalThis as any).navigator = origNav
+            setNavigator(origNav)
             ;(globalThis as any).window = origWin
         }
     })
@@ -2920,7 +2927,7 @@ describe('BeaconReporter', () => {
         const origNav = (globalThis as any).navigator
         const origWin = (globalThis as any).window
         const beaconCalls: any[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { beaconCalls.push(JSON.parse(data)); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { beaconCalls.push(JSON.parse(data)); return true } })
         const mockWindow: any = { onerror: null, addEventListener: () => {} }
         ;(globalThis as any).window = mockWindow
         try {
@@ -2928,7 +2935,7 @@ describe('BeaconReporter', () => {
             mockWindow.onerror('err', 'app.js', 1, 1, new Error('x'))
             expect(beaconCalls[0][0].scope).toBe('global')
         } finally {
-            ;(globalThis as any).navigator = origNav
+            setNavigator(origNav)
             ;(globalThis as any).window = origWin
         }
     })
@@ -2937,7 +2944,7 @@ describe('BeaconReporter', () => {
         const origNav = (globalThis as any).navigator
         const origWin = (globalThis as any).window
         const beaconCalls: any[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { beaconCalls.push(JSON.parse(data)); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { beaconCalls.push(JSON.parse(data)); return true } })
         const listeners: Array<(evt: any) => void> = []
         const mockWindow: any = { onerror: null, addEventListener: (_evt: string, fn: any) => listeners.push(fn) }
         ;(globalThis as any).window = mockWindow
@@ -2948,7 +2955,7 @@ describe('BeaconReporter', () => {
             expect(beaconCalls[0][0].level).toBe('error')
             expect(beaconCalls[0][0].messages[0]).toBe('Unhandled promise rejection')
         } finally {
-            ;(globalThis as any).navigator = origNav
+            setNavigator(origNav)
             ;(globalThis as any).window = origWin
         }
     })
@@ -2956,14 +2963,14 @@ describe('BeaconReporter', () => {
     it('close() flushes pending entries', () => {
         const orig = (globalThis as any).navigator
         const calls: any[] = []
-        ;(globalThis as any).navigator = { sendBeacon: (_url: string, data: string) => { calls.push(JSON.parse(data)); return true } }
+        setNavigator({ sendBeacon: (_url: string, data: string) => { calls.push(JSON.parse(data)); return true } })
         try {
             const reporter = new BeaconReporter({ url: '/logs', maxSize: 100, flushInterval: 0 })
             reporter.log('info', 's', T0, {}, ['closing'])
             reporter.close()
             expect(calls).toHaveLength(1)
         } finally {
-            ;(globalThis as any).navigator = orig
+            setNavigator(orig)
         }
     })
 

--- a/node/src/oauth2/oidc.ts
+++ b/node/src/oauth2/oidc.ts
@@ -99,10 +99,28 @@ let jwksCache = new Cache<any>(async (jwksUri: string) => createJwksGetter(jwksU
 async function createJwksGetter(jwksUri: string, opts: HttpOptions): Promise<any> {
 	const j = await loadJose()
 	// jose v5's createRemoteJWKSet has no custom-fetch hook (customFetch is a v6 export),
-	// so opts.fetchImpl cannot be threaded into JWKS retrieval here — it uses global fetch.
-	return j.createRemoteJWKSet(new URL(jwksUri), {
-		timeoutDuration: opts.timeoutMs,
-	})
+	// so we fetch the JWKS ourselves through fetchWithOptions — which honours opts.fetchImpl,
+	// opts.timeoutMs (via AbortController), opts.headers and retry — then build a *local*
+	// key set from the result. This keeps every caller's fetch implementation isolated.
+	let response: Response
+	try {
+		response = await fetchWithOptions(jwksUri, { method: 'GET' }, opts)
+	} catch (error) {
+		throw new OIDCVerificationError(`jwks fetch failed: ${(error as Error).message}`)
+	}
+	if (response.status < 200 || response.status >= 300) {
+		throw new OIDCVerificationError(`jwks fetch returned ${response.status}`)
+	}
+	let jwks: any
+	try {
+		jwks = await response.json()
+	} catch {
+		throw new OIDCVerificationError('jwks response is not valid JSON')
+	}
+	if (!jwks || !Array.isArray(jwks.keys)) {
+		throw new OIDCVerificationError('jwks response is missing a keys array')
+	}
+	return j.createLocalJWKSet(jwks)
 }
 
 export function clearJwksCache(jwksUri?: string): void {
@@ -162,9 +180,10 @@ export async function verifyIdToken(idToken: string, options: VerifyIdTokenOptio
 			throw new OIDCVerificationError('verifyIdToken: jwksUri or jwks is required')
 		}
 		const httpOpts = options.http ?? {}
-		// Bypass the shared cache when caller supplies a custom fetchImpl — per-call
-		// fetch impls cannot be keyed into a shared cache without SSRF / confused-deputy hazard.
-		if (httpOpts.fetchImpl !== undefined) {
+		// Bypass the shared cache when caller supplies a custom fetchImpl or headers — these
+		// are caller-specific and cannot be keyed into a shared cache without a confused-deputy
+		// / SSRF hazard or leaking one caller's keys to another.
+		if (httpOpts.fetchImpl !== undefined || httpOpts.headers !== undefined) {
 			jwks = await createJwksGetter(options.jwksUri, httpOpts)
 		} else {
 			if (typeof options.jwksCacheMs === 'number' && options.jwksCacheMs > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,8 @@
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -144,6 +146,8 @@
         },
         "node_modules/@babel/compat-data": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -152,6 +156,8 @@
         },
         "node_modules/@babel/core": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -181,6 +187,8 @@
         },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -189,6 +197,8 @@
         },
         "node_modules/@babel/generator": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -204,6 +214,8 @@
         },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -219,6 +231,8 @@
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -227,6 +241,8 @@
         },
         "node_modules/@babel/helper-globals": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -235,6 +251,8 @@
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -247,6 +265,8 @@
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -263,6 +283,8 @@
         },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -271,6 +293,8 @@
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -279,6 +303,8 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -287,6 +313,8 @@
         },
         "node_modules/@babel/helper-validator-option": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -295,6 +323,8 @@
         },
         "node_modules/@babel/helpers": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -307,6 +337,8 @@
         },
         "node_modules/@babel/parser": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -321,6 +353,8 @@
         },
         "node_modules/@babel/plugin-transform-react-jsx-self": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+            "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -335,6 +369,8 @@
         },
         "node_modules/@babel/plugin-transform-react-jsx-source": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+            "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -349,6 +385,8 @@
         },
         "node_modules/@babel/template": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -362,6 +400,8 @@
         },
         "node_modules/@babel/traverse": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -379,6 +419,8 @@
         },
         "node_modules/@babel/types": {
             "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -389,8 +431,88 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/darwin-arm64": {
             "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -404,8 +526,367 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -423,6 +904,8 @@
         },
         "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -434,6 +917,8 @@
         },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -442,6 +927,8 @@
         },
         "node_modules/@eslint/config-array": {
             "version": "0.23.5",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -455,6 +942,8 @@
         },
         "node_modules/@eslint/config-helpers": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -466,6 +955,8 @@
         },
         "node_modules/@eslint/core": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -477,6 +968,8 @@
         },
         "node_modules/@eslint/js": {
             "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -496,6 +989,8 @@
         },
         "node_modules/@eslint/object-schema": {
             "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -504,6 +999,8 @@
         },
         "node_modules/@eslint/plugin-kit": {
             "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -516,6 +1013,8 @@
         },
         "node_modules/@fastify/ajv-compiler": {
             "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+            "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
             "dev": true,
             "funding": [
                 {
@@ -536,6 +1035,8 @@
         },
         "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
             "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -551,11 +1052,15 @@
         },
         "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@fastify/cors": {
             "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
+            "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
             "dev": true,
             "funding": [
                 {
@@ -575,6 +1080,8 @@
         },
         "node_modules/@fastify/error": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+            "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
             "dev": true,
             "funding": [
                 {
@@ -590,6 +1097,8 @@
         },
         "node_modules/@fastify/fast-json-stringify-compiler": {
             "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+            "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
             "dev": true,
             "funding": [
                 {
@@ -608,6 +1117,8 @@
         },
         "node_modules/@fastify/forwarded": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+            "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
             "dev": true,
             "funding": [
                 {
@@ -623,6 +1134,8 @@
         },
         "node_modules/@fastify/merge-json-schemas": {
             "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+            "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
             "dev": true,
             "funding": [
                 {
@@ -641,6 +1154,8 @@
         },
         "node_modules/@fastify/proxy-addr": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+            "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
             "dev": true,
             "funding": [
                 {
@@ -660,6 +1175,8 @@
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -671,6 +1188,8 @@
         },
         "node_modules/@humanfs/node": {
             "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -684,6 +1203,8 @@
         },
         "node_modules/@humanfs/types": {
             "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -692,6 +1213,8 @@
         },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -704,6 +1227,8 @@
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -716,6 +1241,8 @@
         },
         "node_modules/@img/colour": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -723,11 +1250,12 @@
             }
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.33.5",
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -740,15 +1268,38 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.0.4"
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.0.4",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -758,8 +1309,406 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.7.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -769,6 +1718,8 @@
         },
         "node_modules/@jridgewell/remapping": {
             "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -778,6 +1729,8 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -786,11 +1739,15 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -800,10 +1757,14 @@
         },
         "node_modules/@next/env": {
             "version": "16.2.9",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+            "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
             "license": "MIT"
         },
         "node_modules/@next/swc-darwin-arm64": {
             "version": "16.2.9",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+            "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
             "cpu": [
                 "arm64"
             ],
@@ -823,6 +1784,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -838,6 +1800,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -853,6 +1816,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -868,6 +1832,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -883,6 +1848,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -898,6 +1864,7 @@
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -913,6 +1880,7 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -921,13 +1889,341 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@parcel/watcher": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "detect-libc": "^2.0.3",
+                "is-glob": "^4.0.3",
+                "node-addon-api": "^7.0.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.5.6",
+                "@parcel/watcher-darwin-arm64": "2.5.6",
+                "@parcel/watcher-darwin-x64": "2.5.6",
+                "@parcel/watcher-freebsd-x64": "2.5.6",
+                "@parcel/watcher-linux-arm-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm-musl": "2.5.6",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm64-musl": "2.5.6",
+                "@parcel/watcher-linux-x64-glibc": "2.5.6",
+                "@parcel/watcher-linux-x64-musl": "2.5.6",
+                "@parcel/watcher-win32-arm64": "2.5.6",
+                "@parcel/watcher-win32-ia32": "2.5.6",
+                "@parcel/watcher-win32-x64": "2.5.6"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@pinojs/redact": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+            "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -936,6 +2232,8 @@
         },
         "node_modules/@publint/pack": {
             "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.5.tgz",
+            "integrity": "sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -950,6 +2248,8 @@
         },
         "node_modules/@redis/bloom": {
             "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+            "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -961,6 +2261,8 @@
         },
         "node_modules/@redis/client": {
             "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+            "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -984,6 +2286,8 @@
         },
         "node_modules/@redis/json": {
             "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+            "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -995,6 +2299,8 @@
         },
         "node_modules/@redis/search": {
             "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+            "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1006,6 +2312,8 @@
         },
         "node_modules/@redis/time-series": {
             "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+            "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1017,11 +2325,43 @@
         },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.27",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1032,13 +2372,325 @@
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
@@ -1078,6 +2730,8 @@
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1090,6 +2744,8 @@
         },
         "node_modules/@types/babel__generator": {
             "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1098,6 +2754,8 @@
         },
         "node_modules/@types/babel__template": {
             "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1107,6 +2765,8 @@
         },
         "node_modules/@types/babel__traverse": {
             "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1115,6 +2775,8 @@
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1124,26 +2786,36 @@
         },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1152,6 +2824,8 @@
         },
         "node_modules/@types/react": {
             "version": "19.2.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+            "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1160,6 +2834,8 @@
         },
         "node_modules/@types/react-dom": {
             "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -1168,6 +2844,8 @@
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+            "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1195,6 +2873,8 @@
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
             "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1203,6 +2883,8 @@
         },
         "node_modules/@typescript-eslint/parser": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+            "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1226,6 +2908,8 @@
         },
         "node_modules/@typescript-eslint/project-service": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+            "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1246,6 +2930,8 @@
         },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+            "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1262,6 +2948,8 @@
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+            "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1277,6 +2965,8 @@
         },
         "node_modules/@typescript-eslint/type-utils": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+            "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1300,6 +2990,8 @@
         },
         "node_modules/@typescript-eslint/types": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1312,6 +3004,8 @@
         },
         "node_modules/@typescript-eslint/typescript-estree": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+            "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1338,6 +3032,8 @@
         },
         "node_modules/@typescript-eslint/utils": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1360,6 +3056,8 @@
         },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+            "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1376,6 +3074,8 @@
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1395,6 +3095,8 @@
         },
         "node_modules/@vitest/expect": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1411,6 +3113,8 @@
         },
         "node_modules/@vitest/mocker": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1436,6 +3140,8 @@
         },
         "node_modules/@vitest/pretty-format": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1447,6 +3153,8 @@
         },
         "node_modules/@vitest/runner": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1459,6 +3167,8 @@
         },
         "node_modules/@vitest/snapshot": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1473,6 +3183,8 @@
         },
         "node_modules/@vitest/spy": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1481,6 +3193,8 @@
         },
         "node_modules/@vitest/utils": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1494,11 +3208,15 @@
         },
         "node_modules/abstract-logging": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+            "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1510,6 +3228,8 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -1518,6 +3238,8 @@
         },
         "node_modules/ajv": {
             "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1533,6 +3255,8 @@
         },
         "node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1549,6 +3273,8 @@
         },
         "node_modules/ajv-formats/node_modules/ajv": {
             "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1564,11 +3290,15 @@
         },
         "node_modules/ajv-formats/node_modules/json-schema-traverse": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1577,6 +3307,8 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1591,11 +3323,15 @@
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1604,6 +3340,8 @@
         },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1612,6 +3350,8 @@
         },
         "node_modules/avvio": {
             "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+            "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
             "dev": true,
             "funding": [
                 {
@@ -1631,6 +3371,8 @@
         },
         "node_modules/balanced-match": {
             "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1639,6 +3381,8 @@
         },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.38",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -1649,6 +3393,8 @@
         },
         "node_modules/bootstrap-icons": {
             "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+            "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
             "funding": [
                 {
                     "type": "github",
@@ -1663,6 +3409,8 @@
         },
         "node_modules/brace-expansion": {
             "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1674,6 +3422,8 @@
         },
         "node_modules/browserslist": {
             "version": "4.28.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "dev": true,
             "funding": [
                 {
@@ -1706,6 +3456,8 @@
         },
         "node_modules/bundle-require": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+            "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1720,6 +3472,8 @@
         },
         "node_modules/cac": {
             "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1728,6 +3482,8 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001799",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1746,6 +3502,8 @@
         },
         "node_modules/chai": {
             "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1754,6 +3512,8 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1769,6 +3529,8 @@
         },
         "node_modules/chalk/node_modules/supports-color": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1780,6 +3542,8 @@
         },
         "node_modules/chokidar": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1794,10 +3558,14 @@
         },
         "node_modules/client-only": {
             "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
             "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1811,6 +3579,8 @@
         },
         "node_modules/cluster-key-slot": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1819,6 +3589,8 @@
         },
         "node_modules/color": {
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1831,6 +3603,8 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1842,11 +3616,15 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/color-string": {
             "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1856,6 +3634,8 @@
         },
         "node_modules/commander": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1864,6 +3644,8 @@
         },
         "node_modules/concurrently": {
             "version": "9.2.3",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+            "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1887,11 +3669,15 @@
         },
         "node_modules/confbox": {
             "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/consola": {
             "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1900,11 +3686,15 @@
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -1916,6 +3706,8 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1929,11 +3721,15 @@
         },
         "node_modules/csstype": {
             "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1950,11 +3746,15 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/dequal": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1963,6 +3763,8 @@
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1971,21 +3773,29 @@
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.378",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+            "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/es-module-lexer": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2026,6 +3836,8 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2034,6 +3846,8 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2045,6 +3859,8 @@
         },
         "node_modules/eslint": {
             "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -2102,6 +3918,8 @@
         },
         "node_modules/eslint-config-prettier": {
             "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2116,6 +3934,8 @@
         },
         "node_modules/eslint-scope": {
             "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2133,6 +3953,8 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2144,6 +3966,8 @@
         },
         "node_modules/espree": {
             "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2160,6 +3984,8 @@
         },
         "node_modules/esquery": {
             "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -2171,6 +3997,8 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2182,6 +4010,8 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -2190,6 +4020,8 @@
         },
         "node_modules/estree-walker": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2198,6 +4030,8 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -2206,10 +4040,14 @@
         },
         "node_modules/eventemitter3": {
             "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
         },
         "node_modules/expect-type": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2218,21 +4056,29 @@
         },
         "node_modules/fast-decode-uri-component": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-json-stringify": {
             "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+            "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
             "dev": true,
             "funding": [
                 {
@@ -2256,6 +4102,8 @@
         },
         "node_modules/fast-json-stringify/node_modules/ajv": {
             "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2271,16 +4119,22 @@
         },
         "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-querystring": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+            "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2289,6 +4143,8 @@
         },
         "node_modules/fast-uri": {
             "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -2304,6 +4160,8 @@
         },
         "node_modules/fastify": {
             "version": "5.8.5",
+            "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+            "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
             "dev": true,
             "funding": [
                 {
@@ -2336,6 +4194,8 @@
         },
         "node_modules/fastify-plugin": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+            "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
             "dev": true,
             "funding": [
                 {
@@ -2351,6 +4211,8 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2359,6 +4221,8 @@
         },
         "node_modules/fdir": {
             "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2375,6 +4239,8 @@
         },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2386,6 +4252,8 @@
         },
         "node_modules/find-my-way": {
             "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+            "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2399,6 +4267,8 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2414,6 +4284,8 @@
         },
         "node_modules/fix-dts-default-cjs-exports": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+            "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2424,6 +4296,8 @@
         },
         "node_modules/flat-cache": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2436,12 +4310,17 @@
         },
         "node_modules/flatted": {
             "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
+            "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2453,6 +4332,8 @@
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2461,6 +4342,8 @@
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -2469,6 +4352,8 @@
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2480,6 +4365,8 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2488,6 +4375,8 @@
         },
         "node_modules/ignore": {
             "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2496,11 +4385,15 @@
         },
         "node_modules/immutable": {
             "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.7.tgz",
+            "integrity": "sha512-47Xb+LFbZ/ZIjQMj6Q5J3IfK7PJFuqRdFOC9FpGgRTK6U2dAEVmkR9hp58qU4FpYux5YXpneDwkj2EP6lppzFA==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2509,6 +4402,8 @@
         },
         "node_modules/ipaddr.js": {
             "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2517,11 +4412,15 @@
         },
         "node_modules/is-arrayish": {
             "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+            "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2530,6 +4429,8 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2538,6 +4439,8 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2549,11 +4452,15 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/jose": {
             "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+            "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2562,6 +4469,8 @@
         },
         "node_modules/joycon": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2570,11 +4479,15 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2586,11 +4499,15 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-ref-resolver": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+            "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
             "dev": true,
             "funding": [
                 {
@@ -2609,16 +4526,22 @@
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2630,6 +4553,8 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2638,6 +4563,8 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2650,6 +4577,8 @@
         },
         "node_modules/light-my-request": {
             "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+            "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
             "dev": true,
             "funding": [
                 {
@@ -2670,6 +4599,8 @@
         },
         "node_modules/light-my-request/node_modules/process-warning": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+            "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
             "dev": true,
             "funding": [
                 {
@@ -2685,6 +4616,8 @@
         },
         "node_modules/lilconfig": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2696,11 +4629,15 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/load-tsconfig": {
             "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+            "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2709,6 +4646,8 @@
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2723,10 +4662,14 @@
         },
         "node_modules/long": {
             "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2735,10 +4678,14 @@
         },
         "node_modules/lucide-static": {
             "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-1.21.0.tgz",
+            "integrity": "sha512-6248z2/4sEyKkYAPPUYxOPiB2RCfMmLdMHuoOhsTFnoD40ixAoHmTVhOPux8ADa1NTBmzpEKF7WNePm+Ms503Q==",
             "license": "ISC"
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2747,6 +4694,8 @@
         },
         "node_modules/minimatch": {
             "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -2761,6 +4710,8 @@
         },
         "node_modules/mlly": {
             "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+            "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2772,6 +4723,8 @@
         },
         "node_modules/mri": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2780,11 +4733,15 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
             "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2795,6 +4752,8 @@
         },
         "node_modules/nanoid": {
             "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "funding": [
                 {
                     "type": "github",
@@ -2811,11 +4770,15 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/next": {
             "version": "16.2.9",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+            "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
             "license": "MIT",
             "dependencies": {
                 "@next/env": "16.2.9",
@@ -2865,85 +4828,19 @@
                 }
             }
         },
-        "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.5",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "Apache-2.0",
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
+            "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.4"
-            }
-        },
-        "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.4",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "LGPL-3.0-or-later",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
-        "node_modules/next/node_modules/sharp": {
-            "version": "0.34.5",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@img/colour": "^1.0.0",
-                "detect-libc": "^2.1.2",
-                "semver": "^7.7.3"
-            },
-            "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            },
-            "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.5",
-                "@img/sharp-darwin-x64": "0.34.5",
-                "@img/sharp-libvips-darwin-arm64": "1.2.4",
-                "@img/sharp-libvips-darwin-x64": "1.2.4",
-                "@img/sharp-libvips-linux-arm": "1.2.4",
-                "@img/sharp-libvips-linux-arm64": "1.2.4",
-                "@img/sharp-libvips-linux-ppc64": "1.2.4",
-                "@img/sharp-libvips-linux-riscv64": "1.2.4",
-                "@img/sharp-libvips-linux-s390x": "1.2.4",
-                "@img/sharp-libvips-linux-x64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-                "@img/sharp-linux-arm": "0.34.5",
-                "@img/sharp-linux-arm64": "0.34.5",
-                "@img/sharp-linux-ppc64": "0.34.5",
-                "@img/sharp-linux-riscv64": "0.34.5",
-                "@img/sharp-linux-s390x": "0.34.5",
-                "@img/sharp-linux-x64": "0.34.5",
-                "@img/sharp-linuxmusl-arm64": "0.34.5",
-                "@img/sharp-linuxmusl-x64": "0.34.5",
-                "@img/sharp-wasm32": "0.34.5",
-                "@img/sharp-win32-arm64": "0.34.5",
-                "@img/sharp-win32-ia32": "0.34.5",
-                "@img/sharp-win32-x64": "0.34.5"
-            }
+            "peer": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.48",
+            "version": "2.0.49",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
+            "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2952,6 +4849,8 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2960,6 +4859,8 @@
         },
         "node_modules/obug": {
             "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
@@ -2972,6 +4873,8 @@
         },
         "node_modules/on-exit-leak-free": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2980,6 +4883,8 @@
         },
         "node_modules/optionator": {
             "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2996,6 +4901,8 @@
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3010,6 +4917,8 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3024,11 +4933,15 @@
         },
         "node_modules/package-manager-detector": {
             "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3037,6 +4950,8 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3045,11 +4960,15 @@
         },
         "node_modules/pathe": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/phaser": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.2.0.tgz",
+            "integrity": "sha512-9nSQZs4CJ9+V96i2mRC3BBStBcsQWGJJBRpdFYSbpL40/i/QM+wLofaCYMsxNyDk8WJOlHGZUh3uVRKa7lj6yg==",
             "license": "MIT",
             "dependencies": {
                 "eventemitter3": "^5.0.4"
@@ -3057,10 +4976,14 @@
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3072,6 +4995,8 @@
         },
         "node_modules/pino": {
             "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+            "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3093,6 +5018,8 @@
         },
         "node_modules/pino-abstract-transport": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+            "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3101,11 +5028,15 @@
         },
         "node_modules/pino-std-serializers": {
             "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+            "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/pirates": {
             "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3114,6 +5045,8 @@
         },
         "node_modules/pkg-types": {
             "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3124,6 +5057,8 @@
         },
         "node_modules/postcss": {
             "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3150,6 +5085,8 @@
         },
         "node_modules/postcss-load-config": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+            "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
             "dev": true,
             "funding": [
                 {
@@ -3191,6 +5128,8 @@
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3199,6 +5138,8 @@
         },
         "node_modules/prettier": {
             "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3213,6 +5154,8 @@
         },
         "node_modules/process-warning": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
             "dev": true,
             "funding": [
                 {
@@ -3228,6 +5171,8 @@
         },
         "node_modules/protobufjs": {
             "version": "8.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+            "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "long": "^5.3.2"
@@ -3238,6 +5183,8 @@
         },
         "node_modules/publint": {
             "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.21.tgz",
+            "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3258,6 +5205,8 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3266,11 +5215,15 @@
         },
         "node_modules/quick-format-unescaped": {
             "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/react": {
             "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -3278,6 +5231,8 @@
         },
         "node_modules/react-dom": {
             "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
@@ -3288,6 +5243,8 @@
         },
         "node_modules/react-refresh": {
             "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+            "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3296,6 +5253,8 @@
         },
         "node_modules/react-router": {
             "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+            "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -3316,6 +5275,8 @@
         },
         "node_modules/readdirp": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3328,6 +5289,8 @@
         },
         "node_modules/real-require": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3336,6 +5299,8 @@
         },
         "node_modules/redis": {
             "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+            "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3351,6 +5316,8 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3359,6 +5326,8 @@
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3367,6 +5336,8 @@
         },
         "node_modules/resolve-from": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3375,6 +5346,8 @@
         },
         "node_modules/ret": {
             "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+            "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3383,6 +5356,8 @@
         },
         "node_modules/reusify": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3392,11 +5367,15 @@
         },
         "node_modules/rfdc": {
             "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/rollup": {
             "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3440,6 +5419,8 @@
         },
         "node_modules/rxjs": {
             "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3448,6 +5429,8 @@
         },
         "node_modules/sade": {
             "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3459,6 +5442,8 @@
         },
         "node_modules/safe-regex2": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+            "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
             "dev": true,
             "funding": [
                 {
@@ -3480,6 +5465,8 @@
         },
         "node_modules/safe-stable-stringify": {
             "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3488,6 +5475,8 @@
         },
         "node_modules/sass": {
             "version": "1.101.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+            "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3507,6 +5496,8 @@
         },
         "node_modules/sass/node_modules/chokidar": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3521,6 +5512,8 @@
         },
         "node_modules/sass/node_modules/readdirp": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -3533,10 +5526,14 @@
         },
         "node_modules/scheduler": {
             "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
             "license": "MIT"
         },
         "node_modules/secure-json-parse": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+            "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
             "dev": true,
             "funding": [
                 {
@@ -3552,6 +5549,8 @@
         },
         "node_modules/semver": {
             "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "devOptional": true,
             "license": "ISC",
             "bin": {
@@ -3563,21 +5562,27 @@
         },
         "node_modules/server-only": {
             "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+            "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
             "license": "MIT"
         },
         "node_modules/set-cookie-parser": {
             "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
             "license": "MIT"
         },
         "node_modules/sharp": {
-            "version": "0.33.5",
-            "dev": true,
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.3",
-                "semver": "^7.6.3"
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
             },
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -3586,29 +5591,36 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.33.5",
-                "@img/sharp-darwin-x64": "0.33.5",
-                "@img/sharp-libvips-darwin-arm64": "1.0.4",
-                "@img/sharp-libvips-darwin-x64": "1.0.4",
-                "@img/sharp-libvips-linux-arm": "1.0.5",
-                "@img/sharp-libvips-linux-arm64": "1.0.4",
-                "@img/sharp-libvips-linux-s390x": "1.0.4",
-                "@img/sharp-libvips-linux-x64": "1.0.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-                "@img/sharp-linux-arm": "0.33.5",
-                "@img/sharp-linux-arm64": "0.33.5",
-                "@img/sharp-linux-s390x": "0.33.5",
-                "@img/sharp-linux-x64": "0.33.5",
-                "@img/sharp-linuxmusl-arm64": "0.33.5",
-                "@img/sharp-linuxmusl-x64": "0.33.5",
-                "@img/sharp-wasm32": "0.33.5",
-                "@img/sharp-win32-ia32": "0.33.5",
-                "@img/sharp-win32-x64": "0.33.5"
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3620,6 +5632,8 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3628,6 +5642,8 @@
         },
         "node_modules/shell-quote": {
             "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3639,11 +5655,15 @@
         },
         "node_modules/siginfo": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+            "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3652,6 +5672,8 @@
         },
         "node_modules/sonic-boom": {
             "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+            "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3660,6 +5682,8 @@
         },
         "node_modules/source-map": {
             "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3668,6 +5692,8 @@
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -3675,6 +5701,8 @@
         },
         "node_modules/split2": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -3683,16 +5711,22 @@
         },
         "node_modules/stackback": {
             "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/std-env": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3706,6 +5740,8 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3717,6 +5753,8 @@
         },
         "node_modules/styled-jsx": {
             "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+            "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
             "license": "MIT",
             "dependencies": {
                 "client-only": "0.0.1"
@@ -3738,6 +5776,8 @@
         },
         "node_modules/sucrase": {
             "version": "3.35.1",
+            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+            "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3759,6 +5799,8 @@
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3773,6 +5815,8 @@
         },
         "node_modules/thenify": {
             "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3781,6 +5825,8 @@
         },
         "node_modules/thenify-all": {
             "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3792,6 +5838,8 @@
         },
         "node_modules/thread-stream": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+            "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3803,16 +5851,22 @@
         },
         "node_modules/thread-stream/node_modules/real-require": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+            "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tinyexec": {
             "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3821,6 +5875,8 @@
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3836,6 +5892,8 @@
         },
         "node_modules/tinyrainbow": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3844,6 +5902,8 @@
         },
         "node_modules/toad-cache": {
             "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+            "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3852,6 +5912,8 @@
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3860,6 +5922,8 @@
         },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3871,15 +5935,21 @@
         },
         "node_modules/ts-interface-checker": {
             "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/tslib": {
             "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
         "node_modules/tsup": {
             "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+            "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3931,11 +6001,15 @@
         },
         "node_modules/tsup/node_modules/tinyexec": {
             "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3947,6 +6021,8 @@
         },
         "node_modules/typescript": {
             "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -3959,6 +6035,8 @@
         },
         "node_modules/typescript-eslint": {
             "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+            "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3981,16 +6059,22 @@
         },
         "node_modules/ufo": {
             "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -4020,6 +6104,8 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4028,6 +6114,8 @@
         },
         "node_modules/vite": {
             "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4099,8 +6187,78 @@
                 }
             }
         },
+        "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
             "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
             "cpu": [
                 "arm64"
             ],
@@ -4114,8 +6272,367 @@
                 "node": ">=18"
             }
         },
+        "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/vite/node_modules/esbuild": {
             "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -4156,6 +6673,8 @@
         },
         "node_modules/vitest": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4244,6 +6763,8 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4258,6 +6779,8 @@
         },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4273,6 +6796,8 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4281,6 +6806,8 @@
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4297,6 +6824,8 @@
         },
         "node_modules/y18n": {
             "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -4305,11 +6834,15 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4327,6 +6860,8 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -4335,6 +6870,8 @@
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4344,12 +6881,424 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node/node_modules/@types/node": {
-            "version": "20.19.39",
+        "node/node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+            "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "license": "MIT",
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-darwin-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+            "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+            "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+            "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+            "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+            "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+            "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+            "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+            "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+            "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-linux-arm": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+            "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.0.5"
+            }
+        },
+        "node/node_modules/@img/sharp-linux-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+            "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-linux-s390x": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+            "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-linux-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+            "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+            "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+            "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+            }
+        },
+        "node/node_modules/@img/sharp-wasm32": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+            "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "@emnapi/runtime": "^1.2.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-win32-ia32": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+            "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/@img/sharp-win32-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+            "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node/node_modules/sharp": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+            "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "color": "^4.2.3",
+                "detect-libc": "^2.0.3",
+                "semver": "^7.6.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.33.5",
+                "@img/sharp-darwin-x64": "0.33.5",
+                "@img/sharp-libvips-darwin-arm64": "1.0.4",
+                "@img/sharp-libvips-darwin-x64": "1.0.4",
+                "@img/sharp-libvips-linux-arm": "1.0.5",
+                "@img/sharp-libvips-linux-arm64": "1.0.4",
+                "@img/sharp-libvips-linux-s390x": "1.0.4",
+                "@img/sharp-libvips-linux-x64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+                "@img/sharp-linux-arm": "0.33.5",
+                "@img/sharp-linux-arm64": "0.33.5",
+                "@img/sharp-linux-s390x": "0.33.5",
+                "@img/sharp-linux-x64": "0.33.5",
+                "@img/sharp-linuxmusl-arm64": "0.33.5",
+                "@img/sharp-linuxmusl-x64": "0.33.5",
+                "@img/sharp-wasm32": "0.33.5",
+                "@img/sharp-win32-ia32": "0.33.5",
+                "@img/sharp-win32-x64": "0.33.5"
             }
         },
         "phaser-plus": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6883,8 +6883,6 @@
         },
         "node/node_modules/@img/sharp-darwin-arm64": {
             "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-            "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -6929,8 +6927,6 @@
         },
         "node/node_modules/@img/sharp-libvips-darwin-arm64": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-            "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
             "cpu": [
                 "arm64"
             ],
@@ -7263,8 +7259,6 @@
         },
         "node/node_modules/sharp": {
             "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-            "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
@@ -7363,8 +7357,8 @@
             "version": "5.0.0",
             "license": "MIT",
             "dependencies": {
-                "@toolcase/base": "file:../base",
-                "@toolcase/web-components": "file:../web-components",
+                "@toolcase/base": "^5.0.0",
+                "@toolcase/web-components": "^5.0.0",
                 "next": "^16.2.9",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",

--- a/phaser-plus/src/debugger/panels/InspectorPanel.ts
+++ b/phaser-plus/src/debugger/panels/InspectorPanel.ts
@@ -100,7 +100,7 @@ export default class InspectorPanel extends Panel {
         if (this.recorder !== null) {
             this.recorder.ondataavailable = null
             this.recorder.onstop = null
-            try { if (this.recorder.state !== 'inactive') this.recorder.stop() } catch {}
+            try { if (this.recorder.state !== 'inactive') this.recorder.stop() } catch { /* recorder already stopped */ }
             this.recorder = null
         }
         this.videoChunks = []

--- a/phaser-plus/src/engine/GameObject.ts
+++ b/phaser-plus/src/engine/GameObject.ts
@@ -19,7 +19,7 @@ export default class GameObject extends GameObjects.Container {
 
     private _effects: EffectManager | null = null
 
-    private readonly _components: Map<Function, GameObjectComponent> = new Map()
+    private readonly _components: Map<ComponentClass<GameObjectComponent>, GameObjectComponent> = new Map()
 
     private _created: boolean = false
 

--- a/phaser-plus/src/flow/TweenProcessor.ts
+++ b/phaser-plus/src/flow/TweenProcessor.ts
@@ -153,6 +153,7 @@ export default class TweenProcessor extends FlowProcessor {
         this._timelines.push(inst)
         this._log('timeline:start', `${steps.length}steps`)
 
+        // eslint-disable-next-line @typescript-eslint/no-this-alias -- handle methods need the processor instance
         const self = this
         const handle: TimelineHandle = {
             cancel() { inst.cancelled = true },

--- a/phaser-plus/test/GameObjectComponent.test.ts
+++ b/phaser-plus/test/GameObjectComponent.test.ts
@@ -1,4 +1,32 @@
 import { describe, it, expect, vi } from 'vitest'
+
+// Phaser's ESM bundle touches browser-only globals (window, Image, canvas) at
+// module-init time, which throws under the plain-Node vitest environment. The
+// GameObject component-bag logic under test never instantiates Phaser, so we
+// mock the module with minimal class stubs for the symbols read while the
+// src/engine + src/effects import chain evaluates.
+vi.mock('phaser', () => {
+    class PhaserGameObject {}
+    class Container extends PhaserGameObject {
+        preDestroy() {}
+    }
+    class Vector2 {
+        x = 0
+        y = 0
+        constructor(x = 0, y = 0) { this.x = x; this.y = y }
+        set(x: number, y: number) { this.x = x; this.y = y; return this }
+    }
+    class Controller {}
+    class Game {}
+    return {
+        Game,
+        GameObjects: { Container, GameObject: PhaserGameObject },
+        Math: { Vector2 },
+        Filters: { Controller },
+        Cameras: {}
+    }
+})
+
 import GameObject from '../src/engine/GameObject'
 import GameObjectComponent from '../src/engine/GameObjectComponent'
 

--- a/serializer/test/serializer.test.ts
+++ b/serializer/test/serializer.test.ts
@@ -505,15 +505,17 @@ describe('Serializer explicit field tags', () => {
 
 describe('Serializer default constructor — Node 18 crypto compatibility', () => {
     it('constructs and produces a non-empty id when globalThis.crypto is absent', () => {
-        const savedCrypto = (globalThis as any).crypto
+        // globalThis.crypto is a getter-only accessor on modern Node, so a plain
+        // assignment throws; override it via defineProperty (it is configurable).
+        const savedCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto')
         try {
-            (globalThis as any).crypto = undefined
+            Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true, writable: true })
             const s = new Serializer()
             const id: string = (s as any).namespace.name
             expect(id).toBeTruthy()
             expect(id.length).toBeGreaterThan(0)
         } finally {
-            (globalThis as any).crypto = savedCrypto
+            if (savedCrypto) Object.defineProperty(globalThis, 'crypto', savedCrypto)
         }
     })
 })

--- a/taskforge/Dockerfile
+++ b/taskforge/Dockerfile
@@ -1,17 +1,38 @@
 # syntax=docker/dockerfile:1
 
 # ── build stage ──────────────────────────────────────────────────────────────
+# taskforge is an npm workspace whose @toolcase/* deps are `file:../` siblings
+# (base, web-components) consumed from their gitignored built `lib/`. The build
+# therefore needs the WHOLE monorepo, so the CI build context is the repo root
+# (see .github/workflows/taskforge.yml). This Dockerfile lives in taskforge/ but
+# every COPY path below is repo-root-relative.
+#
 # Node >= 22.5 required for the built-in `node:sqlite` module (stable, flag-free
-# on Node 24). See server/db.ts.
+# on Node 24). See taskforge/server/db.ts.
 FROM node:24-slim AS builder
-WORKDIR /app
+WORKDIR /repo
 
-COPY package.json package-lock.json* ./
-RUN npm install
+# Install workspace deps first, keyed only on the manifests so this layer caches
+# across source-only changes. The single root lockfile links the file:../ deps;
+# `npm ci` needs every workspace package.json present to validate against it.
+COPY package.json package-lock.json ./
+COPY base/package.json base/package.json
+COPY logging/package.json logging/package.json
+COPY serializer/package.json serializer/package.json
+COPY web-components/package.json web-components/package.json
+COPY phaser-plus/package.json phaser-plus/package.json
+COPY node/package.json node/package.json
+COPY taskforge/package.json taskforge/package.json
+COPY examples/package.json examples/package.json
+RUN npm ci
 
+# Sources, then build only what taskforge consumes (base, then web-components —
+# order matters: web-components imports base's built `lib/`), then taskforge.
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build
+RUN npm run build --workspace=@toolcase/base \
+    && npm run build --workspace=@toolcase/web-components \
+    && npm run build --workspace=@toolcase/taskforge
 
 # ── runtime stage ────────────────────────────────────────────────────────────
 FROM node:24-slim AS runner
@@ -43,19 +64,21 @@ RUN useradd -m -u 10001 app \
     && mkdir -p /workspace \
     && chown -R app:app /workspace
 
-# Next standalone output
-COPY --from=builder --chown=app:app /app/.next/standalone ./
-COPY --from=builder --chown=app:app /app/.next/static ./.next/static
-COPY --from=builder --chown=app:app /app/public ./public
+# Next standalone output. In a monorepo Next nests the app under its workspace
+# path (taskforge/) inside the standalone tree, so server.js, static and public
+# all sit under ./taskforge — mirror that layout exactly.
+COPY --from=builder --chown=app:app /repo/taskforge/.next/standalone ./
+COPY --from=builder --chown=app:app /repo/taskforge/.next/static ./taskforge/.next/static
+COPY --from=builder --chown=app:app /repo/taskforge/public ./taskforge/public
 # bundled, read-only app-level skills (task-creator, commit-message)
-COPY --from=builder --chown=app:app /app/skills ./skills
+COPY --from=builder --chown=app:app /repo/taskforge/skills ./skills
 
 # run-docker.sh runs the container as an arbitrary HOST uid (to own the bind-
 # mounted /workspace), NOT the image's `app` user. Next writes its incremental /
-# data cache under /app/.next/cache at runtime, so that dir must be writable by
-# any uid — otherwise every cached response logs `EACCES … mkdir /app/.next/cache`.
-RUN mkdir -p /app/.next/cache && chmod -R 0777 /app/.next/cache
+# data cache under taskforge/.next/cache at runtime, so that dir must be writable
+# by any uid — otherwise every cached response logs `EACCES … mkdir .next/cache`.
+RUN mkdir -p /app/taskforge/.next/cache && chmod -R 0777 /app/taskforge/.next/cache
 
 USER app
 EXPOSE 3000
-CMD ["node", "server.js"]
+CMD ["node", "taskforge/server.js"]

--- a/taskforge/components/UsersClient.tsx
+++ b/taskforge/components/UsersClient.tsx
@@ -50,7 +50,6 @@ function RoleSelect({
     // attribute, so a rejected pick would otherwise linger in the native select.
     useEffect(() => {
         if (ref.current) (ref.current as HTMLSelectElement).value = value
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value])
     return (
         <tc-select ref={ref} value={value} disabled={disabled || undefined}>

--- a/taskforge/components/project/AgentPanel.tsx
+++ b/taskforge/components/project/AgentPanel.tsx
@@ -71,7 +71,6 @@ export function AgentPanel({
     useEffect(() => {
         const body = termRef.current?.querySelector('.tc-terminal-window-body')
         if (body) body.scrollTop = body.scrollHeight
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [tcLines])
 
     const logText = () => lines.map((l) => l.text).join('\n')

--- a/taskforge/components/project/RunClient.tsx
+++ b/taskforge/components/project/RunClient.tsx
@@ -73,7 +73,6 @@ export function RunClient() {
     useEffect(() => {
         const body = termRef.current?.querySelector('.tc-terminal-window-body')
         if (body) body.scrollTop = body.scrollHeight
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [tcLines])
 
     const logText = () => lines.map((l) => l.text).join('\n')

--- a/taskforge/lib/icons.ts
+++ b/taskforge/lib/icons.ts
@@ -1,0 +1,78 @@
+// Bootstrap-icons → Lucide name map.
+//
+// The app historically used bootstrap-icons (`bi-<kebab>`); `<tc-icon>` resolves
+// names directly against lucide-static's PascalCase export keys (e.g. "ArrowRight").
+// `tcIcon('box-arrow-right')` → 'LogOut'. Pass the result as `<tc-icon name=…>`.
+//
+// Visual note: Lucide glyphs are line icons and differ from bootstrap-icons.
+// Unmapped names fall back to a best-effort kebab→Pascal guess + a dev warning;
+// an unknown lucide key renders an empty (inert) glyph, so watch for blanks.
+
+const MAP: Record<string, string> = {
+    'arrow-right': 'ArrowRight',
+    github: 'GitBranch', // Lucide has no GitHub brand icon
+    x: 'X',
+    'x-lg': 'X',
+    'box-arrow-right': 'LogOut',
+    'chat-quote': 'MessageSquareQuote',
+    'check-circle': 'CircleCheck',
+    'clock-history': 'History',
+    code: 'Code',
+    collection: 'Library',
+    cpu: 'Cpu',
+    'currency-dollar': 'DollarSign',
+    'diagram-2': 'GitFork',
+    'exclamation-octagon': 'OctagonAlert',
+    'exclamation-triangle': 'TriangleAlert',
+    folder2: 'Folder',
+    'grid-1x2': 'LayoutDashboard',
+    'moon-fill': 'Moon',
+    'pause-circle-fill': 'CirclePause',
+    'play-circle-fill': 'CirclePlay',
+    'heart-pulse': 'HeartPulse',
+    'hourglass-split': 'Hourglass',
+    inbox: 'Inbox',
+    'info-circle': 'Info',
+    'journal-check': 'BookCheck',
+    'journal-text': 'BookText',
+    lightbulb: 'Lightbulb',
+    'link-45deg': 'Link',
+    'list-task': 'ListChecks',
+    'list-ul': 'List',
+    lock: 'Lock',
+    moon: 'Moon',
+    pause: 'Pause',
+    pencil: 'Pencil',
+    people: 'Users',
+    'play-circle': 'CirclePlay',
+    'plus-circle': 'CirclePlus',
+    robot: 'Bot',
+    'skip-forward': 'SkipForward',
+    sliders: 'SlidersHorizontal',
+    speedometer2: 'Gauge',
+    stickies: 'StickyNote',
+    'stop-fill': 'Square',
+    trash: 'Trash2',
+    'type-bold': 'Bold',
+    'type-h1': 'Heading1',
+    'type-italic': 'Italic',
+}
+
+function kebabToPascal(name: string): string {
+    return name
+        .split('-')
+        .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+        .join('')
+}
+
+export function tcIcon(name: string): string {
+    const mapped = MAP[name]
+    if (mapped) return mapped
+    // Already PascalCase (e.g. a lucide name passed straight through)?
+    if (/^[A-Z]/.test(name)) return name
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn(`[tcIcon] no mapping for "${name}" — falling back to a kebab→Pascal guess`)
+    }
+    return kebabToPascal(name)
+}

--- a/taskforge/lib/modal.tsx
+++ b/taskforge/lib/modal.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+// Stacked-modal registry + hooks (unchanged from the old components/ui/modal),
+// with the visual layer swapped to the `<tc-modal>` custom element.
+//
+// `ModalControl`, `ModalContext`, and the `useModal*` hooks are the same React
+// orchestration as before. Only `Window`/`ModalRender` changed: tc-modal now
+// owns the dialog chrome, backdrop, focus-trap, scroll-lock and Escape handling
+// (Bootstrap's Modal plugin), so all of that hand-rolled code is gone.
+
+import React, { createContext, useContext, useEffect, useRef, useState, Children, isValidElement } from 'react'
+
+// ── ModalControl ───────────────────────────────────────────────────────────────
+
+export type ModalDef = {
+    key: string
+    input: any
+    handlePayload?: (payload: any) => void
+}
+
+const CHANGE_EVENT = 'change'
+
+class ModalControl {
+    private defs: ModalDef[] = []
+    private listeners = new Set<() => void>()
+
+    on(_event: string, fn: () => void): void {
+        this.listeners.add(fn)
+    }
+
+    off(_event: string, fn: () => void): void {
+        this.listeners.delete(fn)
+    }
+
+    private emit(): void {
+        this.listeners.forEach((fn) => fn())
+    }
+
+    get current(): ModalDef | null {
+        return this.defs.length > 0 ? this.defs[this.defs.length - 1] : null
+    }
+
+    open(key: string, input?: any, handlePayload?: (payload: any) => void): boolean {
+        if (this.defs.some((def) => def.key === key)) {
+            return false
+        }
+        this.defs.push({ key, input, handlePayload })
+        this.emit()
+        return true
+    }
+
+    close(key?: string, payload?: any): boolean {
+        if (key) {
+            const index = this.defs.findIndex((def) => def.key === key)
+            if (index === -1) return false
+            const def = this.defs[index]
+            this.defs.splice(index, 1)
+            if (def.handlePayload) def.handlePayload(payload ?? null)
+            this.emit()
+            return true
+        }
+        if (this.defs.length === 0) return false
+        const def = this.defs.pop()!
+        if (def.handlePayload) def.handlePayload(payload ?? null)
+        this.emit()
+        return true
+    }
+
+    getAll(): ModalDef[] {
+        return [...this.defs]
+    }
+
+    isOpen(key: string): boolean {
+        return this.defs.some((def) => def.key === key)
+    }
+
+    closeAll(): void {
+        const modalsToClose = [...this.defs]
+        this.defs = []
+        modalsToClose.forEach((def) => {
+            if (def.handlePayload) def.handlePayload(null)
+        })
+        this.emit()
+    }
+}
+
+// ── ModalContext ───────────────────────────────────────────────────────────────
+
+const modalControl = new ModalControl()
+
+const ModalContextValue = createContext<ModalControl | null>(null)
+
+export interface ModalContextProps {
+    children: React.ReactNode
+}
+
+export function ModalContext({ children }: ModalContextProps) {
+    return <ModalContextValue.Provider value={modalControl}>{children}</ModalContextValue.Provider>
+}
+
+function useModalControl(): ModalControl {
+    const context = useContext(ModalContextValue)
+    if (!context) {
+        throw new Error('useModalControl must be used within a ModalContext')
+    }
+    return context
+}
+
+// ── hooks ──────────────────────────────────────────────────────────────────────
+
+export function useModalOpen<Payload = any, Input = any>(
+    key: string,
+    handlePayload?: (payload: Payload | null) => void,
+): (input?: Input) => boolean {
+    const control = useModalControl()
+    return (input?: Input) => control.open(key, input, handlePayload)
+}
+
+export function useModalClose<Payload = any>(key?: string): (payload?: Payload) => boolean {
+    const control = useModalControl()
+    return (payload?: Payload) => {
+        if (key) {
+            return control.close(key, payload)
+        }
+        const current = control.current
+        if (!current) {
+            throw new Error(
+                'useModalClose: No current modal to close. Either provide a key or call from within a modal.',
+            )
+        }
+        return control.close(undefined, payload)
+    }
+}
+
+export function useCurrentModal(): string | null {
+    const control = useModalControl()
+    const current = control.current
+    return current ? current.key : null
+}
+
+export function useModalInput<Input = any>(): Input | null {
+    const control = useModalControl()
+    const current = control.current
+    return current ? current.input : null
+}
+
+export function useModalCloseAll(): () => void {
+    const control = useModalControl()
+    return () => control.closeAll()
+}
+
+// ── Window ─────────────────────────────────────────────────────────────────────
+
+export interface WindowProps {
+    children: React.ReactNode
+    size: 'small' | 'medium' | 'large' | 'xlarge' | 'full'
+    className?: string
+    title?: string
+}
+
+// taskforge size → tc-modal `size` attribute (medium = Bootstrap default, no attr).
+const SIZE_ATTR: Record<WindowProps['size'], string | undefined> = {
+    small: 'sm',
+    medium: undefined,
+    large: 'lg',
+    xlarge: 'xl',
+    full: undefined,
+}
+
+export function Window({ children, size = 'medium', className, title }: WindowProps) {
+    const close = useModalClose()
+    const ref = useRef<HTMLElement>(null)
+    const closingRef = useRef(false)
+
+    // Open on mount; route the element's own dismiss (Escape / backdrop / X) back
+    // through the registry so React state stays the source of truth.
+    useEffect(() => {
+        const el = ref.current
+        if (!el) return
+        ;(el as any).open = true
+        const onHide = () => {
+            if (closingRef.current) return
+            closingRef.current = true
+            close()
+        }
+        el.addEventListener('tc-hide', onHide)
+        return () => el.removeEventListener('tc-hide', onHide)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    const sizeAttr = SIZE_ATTR[size]
+
+    return (
+        // tc-modal captures its light-DOM children ONCE on connect and moves them
+        // into .modal-body. We pass a SINGLE wrapper element so React only ever
+        // mutates inside it — never inserts siblings onto the host (which would
+        // land outside .modal-body). Set structural attrs (title/size) once here.
+        // @ts-ignore — tc-modal is a registered custom element
+        <tc-modal
+            ref={ref}
+            title={title ?? ''}
+            size={sizeAttr}
+            fullscreen={size === 'full' ? 'true' : undefined}
+        >
+            <div className={className}>{children}</div>
+        </tc-modal>
+    )
+}
+
+// ── ModalRender ──────────────────────────────────────────────────────────────
+
+export interface ModalRenderProps {
+    children: React.ReactNode
+    className?: string
+}
+
+export function ModalRender({ children }: ModalRenderProps) {
+    const buildMap = () =>
+        new Map(
+            Children.toArray(children)
+                .filter((child): child is React.ReactElement => isValidElement(child) && child.key != null)
+                // React prefixes element keys with ".$" — strip it back to the modal key.
+                .map((child) => [String(child.key).substring(2), child] as [string, React.ReactElement]),
+        )
+
+    const [windows, setWindows] = useState<Map<string, React.ReactElement>>(buildMap)
+    useEffect(() => {
+        setWindows(buildMap())
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [children])
+
+    const control = useModalControl()
+    const [currentModal, setCurrentModal] = useState<string | null>(null)
+
+    useEffect(() => {
+        const handleChange = () => {
+            const current = control.current
+            setCurrentModal(current ? current.key : null)
+        }
+        handleChange()
+        control.on(CHANGE_EVENT, handleChange)
+        return () => control.off(CHANGE_EVENT, handleChange)
+    }, [control])
+
+    // Render only the top-of-stack modal body; it renders its own <Window>, which
+    // mounts a fresh tc-modal that handles backdrop/focus/scroll/Escape itself.
+    return <>{windows.get(currentModal ?? '') ?? null}</>
+}
+
+// Namespace export so existing `Modal.Window` / `Modal.useModalInput` call sites
+// keep working after changing the import path to `@/lib/modal`.
+export const Modal = {
+    ModalContext,
+    ModalRender,
+    Window,
+    useModalOpen,
+    useModalClose,
+    useCurrentModal,
+    useModalInput,
+    useModalCloseAll,
+}

--- a/taskforge/lib/tc.ts
+++ b/taskforge/lib/tc.ts
@@ -1,0 +1,129 @@
+'use client'
+
+// React 18 ↔ web-components interop.
+//
+// React 18 cannot set object/array values as DOM *properties* through JSX (it
+// stringifies everything into attributes) and cannot subscribe to custom DOM
+// events through JSX `onX` props. Both are required to drive `tc-*` custom
+// elements: charts/tables/selects take rich data as element properties, and
+// form/overlay elements report changes via `change`/`input`/`tc-*` CustomEvents.
+//
+// These hooks return a ref you attach to the `tc-*` element. `useTc` does both;
+// `useTcProps`/`useTcEvents` are conveniences over it.
+//
+// Caller contract: pass a STABLE set of keys (don't conditionally add/remove
+// keys between renders — deps length must stay constant) and `useMemo`
+// array/object property values so identity only changes when the data does.
+
+import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from 'react'
+
+type Handler = (event: any) => void
+
+// Properties apply in a layout effect so they land before paint (no flash of an
+// empty table/select); on the server there is no layout phase, so fall back to
+// useEffect to avoid the React SSR warning. `tc-*` only ever mount client-side.
+const useIsoLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+export function useTc<E extends HTMLElement = HTMLElement>(
+    props?: Record<string, unknown>,
+    handlers?: Record<string, Handler>,
+): RefObject<E | null> {
+    // A *callback ref* — not useRef — is the key. It fires exactly when the element
+    // attaches (with the node) and detaches (with null), so it works even for tc-*
+    // that mount AFTER the owning component's first render (conditional JSX, e.g.
+    // `{commitAfter && <tc-radio-group …>}`). A deps-gated useEffect would never
+    // re-run for that late-attached node, leaving its object props (`options`,
+    // `series`, …) unset and its CustomEvent handlers unbound. The callback form
+    // also pairs attach/detach correctly under React StrictMode's dev remount.
+    const propsRef = useRef(props)
+    propsRef.current = props
+    const handlersRef = useRef(handlers)
+    handlersRef.current = handlers
+    const elRef = useRef<E | null>(null)
+    const cleanupRef = useRef<(() => void) | null>(null)
+
+    const setRef = useCallback((node: E | null) => {
+        // Detach from the previous node first (remove its event listeners).
+        if (cleanupRef.current) {
+            cleanupRef.current()
+            cleanupRef.current = null
+        }
+        elRef.current = node
+        if (!node) return
+
+        // Apply object/array props as element *properties* (JSX can only set them
+        // as stringified attributes, which custom elements can't consume).
+        const p = propsRef.current
+        if (p) for (const [key, value] of Object.entries(p)) (node as any)[key] = value
+
+        // Bind CustomEvent listeners; handlers are read live from the ref so they
+        // can change between renders without rebinding.
+        const names = handlersRef.current ? Object.keys(handlersRef.current) : []
+        const listeners = names.map((name) => {
+            const listener = (event: Event) => handlersRef.current?.[name]?.(event)
+            node.addEventListener(name, listener)
+            return [name, listener] as const
+        })
+        if (listeners.length) {
+            cleanupRef.current = () => listeners.forEach(([name, l]) => node.removeEventListener(name, l))
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // Re-apply props when their VALUES change on an already-attached element (the
+    // callback ref only fires on attach/detach, not on data updates). useMemo the
+    // values at call sites so identity changes only when the data actually does.
+    const propValues = props ? Object.values(props) : []
+    useIsoLayoutEffect(() => {
+        const el = elRef.current
+        const p = propsRef.current
+        if (!el || !p) return
+        for (const [key, value] of Object.entries(p)) (el as any)[key] = value
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, propValues)
+
+    // Expose `.current` (live node) so callers can still read the element, while
+    // the value React receives is the callback form. Defined once on the stable
+    // setRef identity.
+    if (!Object.prototype.hasOwnProperty.call(setRef, 'current')) {
+        Object.defineProperty(setRef, 'current', { get: () => elRef.current })
+    }
+    return setRef as unknown as RefObject<E | null>
+}
+
+export function useTcProps<E extends HTMLElement = HTMLElement>(props: Record<string, unknown>): RefObject<E | null> {
+    return useTc<E>(props, undefined)
+}
+
+export function useTcEvents<E extends HTMLElement = HTMLElement>(handlers: Record<string, Handler>): RefObject<E | null> {
+    return useTc<E>(undefined, handlers)
+}
+
+/**
+ * HTML-escape a value for safe interpolation into a `tc-table` `render` cell
+ * (those return an HTML *string*, not React, so user data must be escaped to
+ * avoid markup injection). Mirrors web-components' internal `esc`.
+ */
+export function escapeHtml(value: unknown): string {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+}
+
+/** Read `.value` off a custom-event target (form elements delegate it). */
+export function targetValue(event: Event): string {
+    return (event.target as any)?.value ?? ''
+}
+
+/** Read `.checked` off a custom-event target. */
+export function targetChecked(event: Event): boolean {
+    return Boolean((event.target as any)?.checked)
+}
+
+/** Read `detail.value` off a `tc-change` CustomEvent (switch/number/markdown/etc). */
+export function detailValue<T = any>(event: Event): T {
+    return (event as CustomEvent).detail?.value
+}

--- a/taskforge/lib/terminal.ts
+++ b/taskforge/lib/terminal.ts
@@ -1,0 +1,25 @@
+// App-side terminal line model. TaskForge's SSE stream tags lines with `kind`
+// ('input' | 'output' | 'comment' | 'error'); tc-terminal-window expects `type`
+// ('command' | 'output' | 'comment'). Keep our richer model and map at the
+// render boundary via `toTcLines`.
+
+import type { TerminalLine as TcTerminalLine } from '@toolcase/web-components'
+
+export type TerminalLineKind = 'input' | 'output' | 'comment' | 'error'
+
+export interface TerminalLine {
+    kind: TerminalLineKind
+    text: string
+    delay?: number
+}
+
+const KIND_TO_TYPE: Record<TerminalLineKind, 'command' | 'output' | 'comment'> = {
+    input: 'command',
+    output: 'output',
+    comment: 'comment',
+    error: 'output', // tc-terminal-window has no error type
+}
+
+export function toTcLines(lines: TerminalLine[]): TcTerminalLine[] {
+    return lines.map((l) => ({ type: KIND_TO_TYPE[l.kind], text: l.text }))
+}

--- a/taskforge/lib/toast.ts
+++ b/taskforge/lib/toast.ts
@@ -1,0 +1,174 @@
+'use client'
+
+// Imperative toast manager built on the `<tc-toast>` custom element.
+//
+// Replaces the old React-context ToastProvider. The public `toast` API is
+// unchanged (`toast.success/error/warning/info(msg, opts)`, `toast(msg, opts)`,
+// `toast.dismiss`, `toast.dismissAll`) so call sites only change the import path.
+//
+// Each toast is a `<tc-toast>` node appended to a fixed-position container. The
+// element captures its child nodes on connect, so we set its attributes and body
+// BEFORE appending it to the DOM, then it renders + shows itself (open attr).
+
+export type ToastVariant = 'success' | 'error' | 'warning' | 'info'
+
+export type ToastPosition =
+    | 'top-right'
+    | 'top-left'
+    | 'top-center'
+    | 'bottom-right'
+    | 'bottom-left'
+    | 'bottom-center'
+
+export interface ToastOptions {
+    id?: string
+    title?: string
+    /** ms before auto-dismiss; `0` keeps it open until dismissed. */
+    duration?: number
+    position?: ToastPosition
+}
+
+const DEFAULT_DURATION = 4000
+const DEFAULT_POSITION: ToastPosition = 'bottom-right'
+const MAX_PER_POSITION = 5
+
+// tc-toast variant → Bootstrap `text-bg-*` colour.
+const VARIANT_BS: Record<ToastVariant, string> = {
+    success: 'success',
+    error: 'danger',
+    warning: 'warning',
+    info: 'info',
+}
+
+const containers = new Map<ToastPosition, HTMLElement>()
+const active = new Map<string, { el: HTMLElement; position: ToastPosition }>()
+let seq = 0
+
+function cornerStyle(position: ToastPosition): Partial<CSSStyleDeclaration> {
+    const [v, h] = position.split('-') as ['top' | 'bottom', 'left' | 'right' | 'center']
+    const style: Partial<CSSStyleDeclaration> = { [v]: '1rem' } as Partial<CSSStyleDeclaration>
+    if (h === 'center') {
+        style.left = '50%'
+        style.transform = 'translateX(-50%)'
+    } else {
+        style[h] = '1rem'
+    }
+    return style
+}
+
+function getContainer(position: ToastPosition): HTMLElement {
+    let container = containers.get(position)
+    if (!container) {
+        container = document.createElement('div')
+        container.setAttribute('data-tc-toast-container', position)
+        Object.assign(container.style, {
+            position: 'fixed',
+            zIndex: '1090', // above modal (1055) and tooltip (1070)
+            display: 'flex',
+            // newest toast nearest the screen edge
+            flexDirection: position.startsWith('bottom') ? 'column-reverse' : 'column',
+            gap: '0.5rem',
+            maxWidth: 'min(420px, 90vw)',
+            pointerEvents: 'none',
+            ...cornerStyle(position),
+        })
+        document.body.appendChild(container)
+        containers.set(position, container)
+    }
+    return container
+}
+
+function add(message: string, variant: ToastVariant, options: ToastOptions = {}): string {
+    if (typeof document === 'undefined') return '' // SSR guard
+
+    const id = options.id ?? `toast-${++seq}`
+    const position = options.position ?? DEFAULT_POSITION
+    const duration = options.duration ?? DEFAULT_DURATION
+    const container = getContainer(position)
+
+    // Cap per-position: drop the oldest still-showing toast at this position.
+    const here = [...active.entries()].filter(([, t]) => t.position === position)
+    if (here.length >= MAX_PER_POSITION) dismiss(here[0][0])
+
+    const el = document.createElement('tc-toast')
+    el.setAttribute('variant', VARIANT_BS[variant])
+    if (options.title) el.setAttribute('title', options.title)
+    if (duration === 0) {
+        el.setAttribute('autohide', 'false')
+    } else {
+        el.setAttribute('autohide', 'true')
+        el.setAttribute('delay', String(duration))
+    }
+    el.style.pointerEvents = 'auto'
+
+    const body = document.createElement('div')
+    body.style.cssText = 'display:flex;align-items:flex-start;gap:.5rem;'
+    const text = document.createElement('span')
+    text.style.flex = '1'
+    text.textContent = message // textContent → no HTML injection
+    body.appendChild(text)
+
+    // tc-toast only renders its own close button when it has a title (header).
+    // Add a manual one otherwise so every toast is dismissable.
+    if (!options.title) {
+        const closeBtn = document.createElement('button')
+        closeBtn.type = 'button'
+        closeBtn.setAttribute('aria-label', 'Dismiss notification')
+        closeBtn.style.cssText =
+            'background:none;border:0;cursor:pointer;color:inherit;opacity:.7;font-size:1.1rem;line-height:1;padding:0 .15rem;'
+        closeBtn.textContent = '×' // ×
+        closeBtn.addEventListener('click', () => (el as any).hide?.())
+        body.appendChild(closeBtn)
+    }
+
+    el.appendChild(body) // children must exist before connect
+    el.setAttribute('open', '')
+    el.addEventListener('tc-hidden', () => {
+        el.remove()
+        active.delete(id)
+    })
+
+    container.appendChild(el) // connect → capture children, render, show
+    active.set(id, { el, position })
+    return id
+}
+
+function dismiss(id: string): void {
+    const t = active.get(id)
+    if (!t) return
+    if (typeof (t.el as any).hide === 'function') {
+        ;(t.el as any).hide() // animates out, then tc-hidden removes it
+    } else {
+        t.el.remove()
+        active.delete(id)
+    }
+}
+
+function dismissAll(): void {
+    for (const id of [...active.keys()]) dismiss(id)
+}
+
+export type ToastFn = {
+    (message: string, options?: ToastOptions & { variant?: ToastVariant }): string
+    success: (message: string, options?: ToastOptions) => string
+    error: (message: string, options?: ToastOptions) => string
+    warning: (message: string, options?: ToastOptions) => string
+    info: (message: string, options?: ToastOptions) => string
+    dismiss: (id: string) => void
+    dismissAll: () => void
+}
+
+export const toast: ToastFn = Object.assign(
+    (message: string, options: ToastOptions & { variant?: ToastVariant } = {}) => {
+        const { variant = 'info', ...rest } = options
+        return add(message, variant, rest)
+    },
+    {
+        success: (message: string, options?: ToastOptions) => add(message, 'success', options),
+        error: (message: string, options?: ToastOptions) => add(message, 'error', options),
+        warning: (message: string, options?: ToastOptions) => add(message, 'warning', options),
+        info: (message: string, options?: ToastOptions) => add(message, 'info', options),
+        dismiss,
+        dismissAll,
+    },
+)

--- a/taskforge/package.json
+++ b/taskforge/package.json
@@ -11,8 +11,8 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@toolcase/base": "file:../base",
-        "@toolcase/web-components": "file:../web-components",
+        "@toolcase/base": "^5.0.0",
+        "@toolcase/web-components": "^5.0.0",
         "next": "^16.2.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",

--- a/taskforge/server/services/settings.ts
+++ b/taskforge/server/services/settings.ts
@@ -54,6 +54,7 @@ export function saveProjectSettings(project: string, settings: ProjectSettings):
         // must name a known account.
         let accounts: typeof import('@/server/services/accounts') | undefined
         try {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports -- intentional sync conditional load; module may be absent
             accounts = require('@/server/services/accounts')
         } catch {
             accounts = undefined

--- a/web-components/scripts/gen-react-types.mjs
+++ b/web-components/scripts/gen-react-types.mjs
@@ -69,7 +69,7 @@ const scanConsts = (src) => {
     }
 }
 for (const dir of [srcDir, join(srcDir, 'internal')]) {
-    let files = []
+    let files
     try {
         files = readdirSync(dir)
     } catch {

--- a/web-components/src/AdvancedTable.ts
+++ b/web-components/src/AdvancedTable.ts
@@ -117,7 +117,8 @@ export class AdvancedTable extends HTMLElement {
         return this.hasAttribute('loading')
     }
     set loading(v: boolean) {
-        v ? this.setAttribute('loading', '') : this.removeAttribute('loading')
+        if (v) this.setAttribute('loading', '')
+        else this.removeAttribute('loading')
     }
 
     // ── JS properties ─────────────────────────────────────────────────────────

--- a/web-components/src/Banner.ts
+++ b/web-components/src/Banner.ts
@@ -184,7 +184,7 @@ export class Banner extends HTMLElement {
         if (key) {
             try {
                 localStorage.setItem(key, 'dismissed')
-            } catch {}
+            } catch { /* storage unavailable */ }
         }
         this.hidden = true
         this.dispatchEvent(new CustomEvent('tc-dismiss', { bubbles: true, composed: true }))

--- a/web-components/src/Build.ts
+++ b/web-components/src/Build.ts
@@ -26,10 +26,10 @@ function lucideHtml(name: string, className?: string): string {
 }
 
 function formatBytes(bytes: number): string {
-    if (bytes < 1024) return `${bytes} B`
-    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`
-    if (bytes < 1073741824) return `${(bytes / 1048576).toFixed(1)} MB`
-    return `${(bytes / 1073741824).toFixed(2)} GB`
+    if (bytes < 1024) return `${bytes}\u00A0B`
+    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)}\u00A0KB`
+    if (bytes < 1073741824) return `${(bytes / 1048576).toFixed(1)}\u00A0MB`
+    return `${(bytes / 1073741824).toFixed(2)}\u00A0GB`
 }
 
 function formatDuration(ms: number): string {
@@ -37,10 +37,10 @@ function formatDuration(ms: number): string {
     if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
     const m = Math.floor(ms / 60000)
     const s = Math.round((ms % 60000) / 1000)
-    if (ms < 3600000) return s > 0 ? `${m}m ${s}s` : `${m}m`
+    if (ms < 3600000) return s > 0 ? `${m}m\u00A0${s}s` : `${m}m`
     const h = Math.floor(ms / 3600000)
     const rem = Math.floor((ms % 3600000) / 60000)
-    return rem > 0 ? `${h}h ${rem}m` : `${h}h`
+    return rem > 0 ? `${h}h\u00A0${rem}m` : `${h}h`
 }
 
 // Resolved once at module load — always rendered when a menu is present

--- a/web-components/src/ChipGroup.ts
+++ b/web-components/src/ChipGroup.ts
@@ -54,7 +54,6 @@ export class ChipGroup extends HTMLElement {
     get title(): string {
         return this.getAttribute('title') ?? ''
     }
-    // @ts-ignore — intentionally widens setter to accept Node alongside string
     set title(v: string | Node) {
         if (v instanceof Node) {
             this._titleProp = v

--- a/web-components/src/Col.ts
+++ b/web-components/src/Col.ts
@@ -53,14 +53,16 @@ export class Col extends HTMLElement {
         return this.getAttribute('span')
     }
     set span(v: string | null) {
-        v != null ? this.setAttribute('span', v) : this.removeAttribute('span')
+        if (v != null) this.setAttribute('span', v)
+        else this.removeAttribute('span')
     }
 
     get order(): string | null {
         return this.getAttribute('order')
     }
     set order(v: string | null) {
-        v != null ? this.setAttribute('order', v) : this.removeAttribute('order')
+        if (v != null) this.setAttribute('order', v)
+        else this.removeAttribute('order')
     }
 
     private resolveSpanClasses(): string[] {

--- a/web-components/src/CoolNav.ts
+++ b/web-components/src/CoolNav.ts
@@ -286,7 +286,7 @@ export class CoolNav extends HTMLElement {
         this.classList.add(`tc-cool-nav--${theme}`)
 
         // Brand area
-        let brandHtml = ''
+        let brandHtml: string
         if (brand !== null) {
             brandHtml =
                 `<a class="tc-cool-nav-brand" href="#" aria-label="${esc(brand)}">` +

--- a/web-components/src/EquipmentDoll.ts
+++ b/web-components/src/EquipmentDoll.ts
@@ -173,7 +173,7 @@ export class EquipmentDoll extends HTMLElement {
         if (!item) return ''
         const icon = item.icon
         const name = item.name ?? item.id
-        let glyphMarkup = ''
+        let glyphMarkup: string
         if (icon && isImageSrc(icon)) {
             glyphMarkup = `<img class="tc-equipment-doll__icon" src="${esc(icon)}" alt="" />`
         } else {

--- a/web-components/src/JSONSchemaDef.ts
+++ b/web-components/src/JSONSchemaDef.ts
@@ -577,7 +577,7 @@ export class JSONSchemaDef extends HTMLElement {
             `.tc-json-schema-def-row[data-idx="${focus.idx}"]`,
         )
         if (!row) return
-        let el: HTMLElement | null = null
+        let el: HTMLElement | null
         if (focus.field === 'key') el = row.querySelector('.tc-json-schema-def-key')
         else if (focus.field === 'type') el = row.querySelector('.tc-json-schema-def-type')
         else el = row.querySelector(`[data-action="${focus.field}"]`)

--- a/web-components/src/Row.ts
+++ b/web-components/src/Row.ts
@@ -49,7 +49,8 @@ export class Row extends HTMLElement {
         return this.getAttribute('cols')
     }
     set cols(v: string | null) {
-        v != null ? this.setAttribute('cols', v) : this.removeAttribute('cols')
+        if (v != null) this.setAttribute('cols', v)
+        else this.removeAttribute('cols')
     }
 
     get align(): AlignItems | null {
@@ -57,7 +58,8 @@ export class Row extends HTMLElement {
         return v === 'start' || v === 'center' || v === 'end' ? v : null
     }
     set align(v: AlignItems | null) {
-        v ? this.setAttribute('align', v) : this.removeAttribute('align')
+        if (v) this.setAttribute('align', v)
+        else this.removeAttribute('align')
     }
 
     get justify(): JustifyContent | null {
@@ -72,7 +74,8 @@ export class Row extends HTMLElement {
             : null
     }
     set justify(v: JustifyContent | null) {
-        v ? this.setAttribute('justify', v) : this.removeAttribute('justify')
+        if (v) this.setAttribute('justify', v)
+        else this.removeAttribute('justify')
     }
 
     private resolveGutterClasses(): string[] {

--- a/web-components/src/Slider.ts
+++ b/web-components/src/Slider.ts
@@ -274,7 +274,7 @@ export class Slider extends HTMLElement {
         const max = this.max
         const bigStep = step * 10
         const value = this._currentValue()
-        let next = value
+        let next: number
 
         switch (e.key) {
             case 'ArrowLeft':

--- a/web-components/src/Table.ts
+++ b/web-components/src/Table.ts
@@ -112,42 +112,48 @@ export class Table extends HTMLElement {
         return this.hasAttribute('striped')
     }
     set striped(v: boolean) {
-        v ? this.setAttribute('striped', '') : this.removeAttribute('striped')
+        if (v) this.setAttribute('striped', '')
+        else this.removeAttribute('striped')
     }
 
     get hoverable(): boolean {
         return this.hasAttribute('hoverable')
     }
     set hoverable(v: boolean) {
-        v ? this.setAttribute('hoverable', '') : this.removeAttribute('hoverable')
+        if (v) this.setAttribute('hoverable', '')
+        else this.removeAttribute('hoverable')
     }
 
     get compact(): boolean {
         return this.hasAttribute('compact')
     }
     set compact(v: boolean) {
-        v ? this.setAttribute('compact', '') : this.removeAttribute('compact')
+        if (v) this.setAttribute('compact', '')
+        else this.removeAttribute('compact')
     }
 
     get borderless(): boolean {
         return this.hasAttribute('borderless')
     }
     set borderless(v: boolean) {
-        v ? this.setAttribute('borderless', '') : this.removeAttribute('borderless')
+        if (v) this.setAttribute('borderless', '')
+        else this.removeAttribute('borderless')
     }
 
     get stickyHeader(): boolean {
         return this.hasAttribute('sticky-header')
     }
     set stickyHeader(v: boolean) {
-        v ? this.setAttribute('sticky-header', '') : this.removeAttribute('sticky-header')
+        if (v) this.setAttribute('sticky-header', '')
+        else this.removeAttribute('sticky-header')
     }
 
     get loading(): boolean {
         return this.hasAttribute('loading')
     }
     set loading(v: boolean) {
-        v ? this.setAttribute('loading', '') : this.removeAttribute('loading')
+        if (v) this.setAttribute('loading', '')
+        else this.removeAttribute('loading')
     }
 
     get loadingRows(): number {

--- a/web-components/src/internal/dialog-base.ts
+++ b/web-components/src/internal/dialog-base.ts
@@ -187,7 +187,8 @@ export abstract class DialogBase extends HTMLElement {
         if (inert) {
             // Collect ancestors so we can exclude the dialog's own branch.
             const ancestors = new Set<Element>()
-            let el: Element | null = this
+            ancestors.add(this)
+            let el: Element | null = this.parentElement
             while (el && el !== document.body) {
                 ancestors.add(el)
                 el = el.parentElement

--- a/web-components/src/useTc.ts
+++ b/web-components/src/useTc.ts
@@ -58,7 +58,6 @@ export function useTc<E extends HTMLElement = HTMLElement>(
             pairs.forEach(({ event, fn }) => el.removeEventListener(event, fn))
         }
         // Mount-only: event names are static; handlers stay current via onRef.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // Apply instance props after every render so the element stays in sync with


### PR DESCRIPTION
Bug fixes:
- base/BPlusIndex: collect leaf IDs via authoritative tree descent instead of the post-COW-unreliable nextPageId sibling chain; normalize -0 → +0 on number deserialize.
- base/Vec2.negate: avoid producing -0 for zero components.
- base/SpatialHash.nearest: return null on empty set; honor maxDist as a hard ring-search cutoff.
- base/formatByteSize: treat sub-1-byte values as "0 Bytes".
- base/slugify: keep underscores as word separators.
- logging/StreamReporter: rotate only after the first line and on >= maxBytes.
- node/oidc: thread caller fetchImpl/headers/timeout/retry into JWKS retrieval via fetchWithOptions + createLocalJWKSet; bypass shared cache for custom headers too (confused-deputy/SSRF guard).
- web-components/dialog-base: include self + parent chain when collecting inert ancestors.

Lint/style:
- eslint: scope scripts glob to **/scripts/**; relax namespace/empty-interface rules for generated react-types.ts.
- Replace value-returning ternaries with if/else, let → const, function exprs → arrows; annotate intentional no-this-alias / empty-catch / require.
- Drop stale react-hooks/exhaustive-deps disables.

Tests:
- Stub navigator/crypto via Object.defineProperty (getter-only on modern Node).
- Mock phaser in GameObjectComponent test to avoid browser-global init.
- Correct Color luminance (#767676 ≈ 0.1812), DisjointSet count, PageCache LRU expectations.