### PR TITLE
feat(quaykeeper): split log destinations into reusable endpoints

### DIFF
--- a/quaykeeper/app/api/admin/log-destinations/[id]/route.ts
+++ b/quaykeeper/app/api/admin/log-destinations/[id]/route.ts
@@ -1,15 +1,16 @@
-// PATCH  /api/admin/log-destinations/{id} — replace a destination (name is immutable;
-//        send the full LogDestination + { scope, target }).
-// DELETE /api/admin/log-destinations/{id} — remove the row and (global scope) retract
-//        its daemon fragment.
+// PATCH  /api/admin/log-destinations/{id} — replace an endpoint (name is immutable;
+//        send the full DestinationEndpoint). Every enabled realm binding referencing
+//        it is re-pushed to its own realm; instance bindings refresh via the
+//        agent-snapshot version bump.
+// DELETE /api/admin/log-destinations/{id} — remove the endpoint. Blocked with 409
+//        `destination_in_use` while any binding references it.
 //
-// Both guarded by `authorize('owner')` (G21). Validation + the daemon push/retract +
-// audit live in `services/log-destinations.ts`.
+// Both guarded by `authorize('owner')` (G21). Validation + the re-push + audit live
+// in `services/log-destinations.ts`.
 
 import { NextResponse } from 'next/server'
 import { authorize } from '@/server/services/auth'
 import * as logDests from '@/server/services/log-destinations'
-import * as realms from '@/server/services/realms'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -30,8 +31,7 @@ export async function PATCH(req: Request, ctx: Ctx) {
     const { id } = await ctx.params
     try {
         const actor = { githubId: authz.session.sub, login: authz.session.login }
-        const client = await realms.clientForActive(authz.session.sub, authz.role)
-        const { value, warnings } = await logDests.update(client, actor, id, body)
+        const { value, warnings } = await logDests.update(actor, id, body)
         return NextResponse.json({ ...value, warnings })
     } catch (err) {
         const { status, code, detail } = logDests.httpErrorFor(err)
@@ -46,8 +46,7 @@ export async function DELETE(_req: Request, ctx: Ctx) {
     const { id } = await ctx.params
     try {
         const actor = { githubId: authz.session.sub, login: authz.session.login }
-        const client = await realms.clientForActive(authz.session.sub, authz.role)
-        await logDests.remove(client, actor, id)
+        logDests.remove(actor, id)
         return new NextResponse(null, { status: 204 })
     } catch (err) {
         const { status, code, detail } = logDests.httpErrorFor(err)

--- a/quaykeeper/app/api/admin/log-destinations/route.ts
+++ b/quaykeeper/app/api/admin/log-destinations/route.ts
@@ -1,17 +1,16 @@
-// GET  /api/admin/log-destinations — list configured log-shipping destinations
-//      (secrets as env/file refs only — safe to serialize).
-// POST /api/admin/log-destinations — create a destination (JSON LogDestination body,
-//      plus optional { scope, target }).
+// GET  /api/admin/log-destinations — list the reusable destination endpoints
+//      (secrets as env/file refs only — safe to serialize) with their usedBy counts.
+// POST /api/admin/log-destinations — create an endpoint (JSON DestinationEndpoint
+//      body: name/type/url/tenant/TLS/auth). Persist-only — a bare endpoint ships
+//      nothing until a realm or instance binds it, so no daemon is touched.
 //
 // Both guarded by `authorize('owner')` — every destination carries a URL and the
-// pipeline egresses log data, so per G21 only the owner creates/edits. Validation,
-// persistence, the daemon push (global scope) and the audit entry live in
-// `services/log-destinations.ts`.
+// pipeline egresses log data, so per G21 only the owner creates/edits endpoints.
+// Validation, persistence and the audit entry live in `services/log-destinations.ts`.
 
 import { NextResponse } from 'next/server'
 import { authorize } from '@/server/services/auth'
 import * as logDests from '@/server/services/log-destinations'
-import * as realms from '@/server/services/realms'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -36,9 +35,8 @@ export async function POST(req: Request) {
 
     try {
         const actor = { githubId: authz.session.sub, login: authz.session.login }
-        const client = await realms.clientForActive(authz.session.sub, authz.role)
-        const { value, warnings } = await logDests.create(client, actor, body)
-        return NextResponse.json({ ...value, warnings }, { status: 201 })
+        const value = logDests.create(actor, body)
+        return NextResponse.json(value, { status: 201 })
     } catch (err) {
         const { status, code, detail } = logDests.httpErrorFor(err)
         return NextResponse.json({ error: code, detail }, { status })

--- a/quaykeeper/app/api/admin/log-destinations/status/route.ts
+++ b/quaykeeper/app/api/admin/log-destinations/status/route.ts
@@ -1,5 +1,8 @@
-// GET /api/admin/log-destinations/status — per-destination shipping stats + intake
-//     health from the active realm's daemon (`GET /logs/status`), for the live table.
+// GET /api/admin/log-destinations/status[?realm=<id>] — per-destination shipping
+//     stats + intake health from one realm's daemon (`GET /logs/status`). With
+//     `?realm=` the stats come from that realm's client (the Servers-page binding
+//     modal, D4 — stats are per fragment name on a specific daemon); without it,
+//     from the caller's active realm.
 //
 // Guarded by `authorize('owner')`.
 
@@ -11,12 +14,15 @@ import * as realms from '@/server/services/realms'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(req: Request) {
     const authz = await authorize('owner')
     if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
 
     try {
-        const client = await realms.clientForActive(authz.session.sub, authz.role)
+        const realmId = new URL(req.url).searchParams.get('realm')
+        const client = realmId
+            ? realms.clientFor(realmId)
+            : await realms.clientForActive(authz.session.sub, authz.role)
         return NextResponse.json(await logDests.logsStatus(client))
     } catch (err) {
         const { status, code, detail } = logDests.httpErrorFor(err)

--- a/quaykeeper/app/api/admin/realms/[id]/log-bindings/route.ts
+++ b/quaykeeper/app/api/admin/realms/[id]/log-bindings/route.ts
@@ -1,0 +1,67 @@
+// GET    /api/admin/realms/{id}/log-bindings — this realm's log binding(s), joined
+//        with destination identity (the Servers-page modal shows the first — the UI
+//        is one-destination-per-realm).
+// PUT    /api/admin/realms/{id}/log-bindings — set the realm's binding
+//        ({ destinationId, enabled?, shaping? }). Pushes/retracts the fragment on
+//        THAT realm's own nginxpilot; rolls the row back if the daemon rejects it.
+// DELETE /api/admin/realms/{id}/log-bindings — clear the realm's binding(s):
+//        retract the fragment (best-effort), then drop the row.
+//
+// All guarded by `authorize('owner')` (realm bindings drive the shared edge).
+// Validation, the daemon push/retract and audit live in `services/log-bindings.ts`.
+
+import { NextResponse } from 'next/server'
+import { authorize } from '@/server/services/auth'
+import * as logBindings from '@/server/services/log-bindings'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+export async function GET(_req: Request, ctx: Ctx) {
+    const authz = await authorize('owner')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    const { id } = await ctx.params
+    return NextResponse.json(logBindings.listForRealm(id))
+}
+
+export async function PUT(req: Request, ctx: Ctx) {
+    const authz = await authorize('owner')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    let body: { destinationId?: unknown; enabled?: unknown; shaping?: unknown }
+    try {
+        body = (await req.json()) as { destinationId?: unknown; enabled?: unknown; shaping?: unknown }
+    } catch {
+        return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+    }
+
+    const { id } = await ctx.params
+    try {
+        const actor = { githubId: authz.session.sub, login: authz.session.login }
+        const value = await logBindings.setRealmBinding(actor, id, body)
+        return NextResponse.json(value)
+    } catch (err) {
+        const { status, code, detail } = logBindings.httpErrorFor(err)
+        return NextResponse.json({ error: code, detail }, { status })
+    }
+}
+
+export async function DELETE(_req: Request, ctx: Ctx) {
+    const authz = await authorize('owner')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    const { id } = await ctx.params
+    try {
+        const actor = { githubId: authz.session.sub, login: authz.session.login }
+        for (const binding of logBindings.listForRealm(id)) {
+            await logBindings.removeRealmBinding(actor, binding.id)
+        }
+        return new NextResponse(null, { status: 204 })
+    } catch (err) {
+        const { status, code, detail } = logBindings.httpErrorFor(err)
+        return NextResponse.json({ error: code, detail }, { status })
+    }
+}

--- a/quaykeeper/app/api/instances/[id]/logs/[bindingId]/route.ts
+++ b/quaykeeper/app/api/instances/[id]/logs/[bindingId]/route.ts
@@ -1,0 +1,52 @@
+// PATCH  /api/instances/{id}/logs/{bindingId} — update a binding's enabled flag /
+//        shaping ({ enabled?, shaping? }).
+// DELETE /api/instances/{id}/logs/{bindingId} — unbind the destination.
+//
+// Guarded by `authorize('maintainer')` (D3). Stored only — the agent snapshot's
+// version bump propagates the change to quaykeeper-client on its next poll.
+
+import { NextResponse } from 'next/server'
+import { authorize } from '@/server/services/auth'
+import * as logBindings from '@/server/services/log-bindings'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type Ctx = { params: Promise<{ id: string; bindingId: string }> }
+
+export async function PATCH(req: Request, ctx: Ctx) {
+    const authz = await authorize('maintainer')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    let body: { enabled?: unknown; shaping?: unknown }
+    try {
+        body = (await req.json()) as { enabled?: unknown; shaping?: unknown }
+    } catch {
+        return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+    }
+
+    const { id, bindingId } = await ctx.params
+    try {
+        const actor = { githubId: authz.session.sub, login: authz.session.login }
+        const value = logBindings.updateInstanceBinding(actor, id, bindingId, body)
+        return NextResponse.json(value)
+    } catch (err) {
+        const { status, code, detail } = logBindings.httpErrorFor(err)
+        return NextResponse.json({ error: code, detail }, { status })
+    }
+}
+
+export async function DELETE(_req: Request, ctx: Ctx) {
+    const authz = await authorize('maintainer')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    const { id, bindingId } = await ctx.params
+    try {
+        const actor = { githubId: authz.session.sub, login: authz.session.login }
+        logBindings.removeInstanceBinding(actor, id, bindingId)
+        return new NextResponse(null, { status: 204 })
+    } catch (err) {
+        const { status, code, detail } = logBindings.httpErrorFor(err)
+        return NextResponse.json({ error: code, detail }, { status })
+    }
+}

--- a/quaykeeper/app/api/instances/[id]/logs/route.ts
+++ b/quaykeeper/app/api/instances/[id]/logs/route.ts
@@ -1,0 +1,56 @@
+// GET  /api/instances/{id}/logs — this instance's log bindings (joined with
+//      destination identity) plus the owner-defined destination options the
+//      binding modal's select offers (id/name/type/url only — refs, no auth).
+// POST /api/instances/{id}/logs — bind a destination to this instance
+//      ({ destinationId, enabled?, shaping? }; upserts on the same destination).
+//
+// Guarded by `authorize('maintainer')` like the other instance routes (D3):
+// maintainers *choose* from owner-defined destinations; only the owner creates
+// endpoints. Stored only — no daemon call; quaykeeper-client picks the change up
+// via the agent snapshot's version bump on its next poll.
+
+import { NextResponse } from 'next/server'
+import { authorize } from '@/server/services/auth'
+import * as instanceRepo from '@/server/data/repositories/instance-repo'
+import * as logDests from '@/server/services/log-destinations'
+import * as logBindings from '@/server/services/log-bindings'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+export async function GET(_req: Request, ctx: Ctx) {
+    const authz = await authorize('maintainer')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    const { id } = await ctx.params
+    if (!instanceRepo.byId(id)) return NextResponse.json({ error: 'instance_not_found' }, { status: 404 })
+
+    const destinations = logDests
+        .list()
+        .map((d) => ({ id: d.id, name: d.name, type: d.type, url: d.spec.url }))
+    return NextResponse.json({ bindings: logBindings.listForInstance(id), destinations })
+}
+
+export async function POST(req: Request, ctx: Ctx) {
+    const authz = await authorize('maintainer')
+    if (!authz.ok) return NextResponse.json({ error: 'unauthorized' }, { status: authz.status })
+
+    let body: { destinationId?: unknown; enabled?: unknown; shaping?: unknown }
+    try {
+        body = (await req.json()) as { destinationId?: unknown; enabled?: unknown; shaping?: unknown }
+    } catch {
+        return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+    }
+
+    const { id } = await ctx.params
+    try {
+        const actor = { githubId: authz.session.sub, login: authz.session.login }
+        const value = logBindings.setInstanceBinding(actor, id, body)
+        return NextResponse.json(value, { status: 201 })
+    } catch (err) {
+        const { status, code, detail } = logBindings.httpErrorFor(err)
+        return NextResponse.json({ error: code, detail }, { status })
+    }
+}

--- a/quaykeeper/app/instances/[id]/logs/page.tsx
+++ b/quaykeeper/app/instances/[id]/logs/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+import { AuthGate } from '@/components/AuthGate'
+import { InstanceDetail } from '@/components/config/InstanceDetail'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = { title: 'Logs · Instance' }
+
+export default async function InstanceLogsPage({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params
+    return (
+        <AuthGate>
+            <InstanceDetail instanceId={id} tab="logs" />
+        </AuthGate>
+    )
+}

--- a/quaykeeper/app/instances/page.tsx
+++ b/quaykeeper/app/instances/page.tsx
@@ -5,7 +5,7 @@ import { Instances } from '@/components/config/Instances'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-export const metadata: Metadata = { title: 'Variables' }
+export const metadata: Metadata = { title: 'Instances' }
 
 export default function InstancesPage() {
     return (

--- a/quaykeeper/components/AppShell.tsx
+++ b/quaykeeper/components/AppShell.tsx
@@ -49,7 +49,7 @@ export function AppShell({ me, children }: { me: MeResponse; children: ReactNode
                     ? [
                           {
                               key: 'instances',
-                              label: 'Variables',
+                              label: 'Instances',
                               icon: 'server',
                               href: '/instances',
                               active: pathname.startsWith('/instances'),

--- a/quaykeeper/components/Breadcrumbs.tsx
+++ b/quaykeeper/components/Breadcrumbs.tsx
@@ -28,7 +28,7 @@ const ADMIN_LABELS: Record<string, string> = {
 
 function trailFor(pathname: string): Crumb[] {
     if (pathname.startsWith('/sites/')) return [{ label: 'Static Sites', href: '/' }, { label: 'Site' }]
-    if (pathname.startsWith('/instances/')) return [{ label: 'Variables', href: '/instances' }, { label: 'Instance' }]
+    if (pathname.startsWith('/instances/')) return [{ label: 'Instances', href: '/instances' }, { label: 'Instance' }]
     if (pathname.startsWith('/databases/')) return [{ label: 'Databases', href: '/databases' }, { label: 'Server' }]
     if (pathname.startsWith('/proxies')) return [{ label: 'Routing' }, { label: 'Proxies' }]
     if (pathname.startsWith('/admin')) {

--- a/quaykeeper/components/CommandPalette.tsx
+++ b/quaykeeper/components/CommandPalette.tsx
@@ -31,7 +31,7 @@ export function CommandPalette() {
         ]
         if (ROLE_RANK[me.role] >= ROLE_RANK.maintainer) {
             list.push(
-                { id: 'instances', label: 'Variables', group: 'Navigate', icon: 'server', href: '/instances' },
+                { id: 'instances', label: 'Instances', group: 'Navigate', icon: 'server', href: '/instances' },
                 { id: 'db-servers', label: 'Databases', group: 'Navigate', icon: 'database', href: '/databases' },
                 { id: 'snippets', label: 'Docker snippets', group: 'Navigate', icon: 'container', href: '/snippets' },
                 { id: 'proxies', label: 'Proxies', group: 'Routing', icon: 'globe', href: '/proxies' },

--- a/quaykeeper/components/LogShapingFields.tsx
+++ b/quaykeeper/components/LogShapingFields.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { FormGroup } from '@/components/FormModal'
+import { SelectField, TextAreaField, TextField } from '@/components/fields'
+import type { LogShaping } from '@/server/domain/nginxpilot-logdest-fragment'
+
+// Shared shaping sub-form for log bindings (logs_feature.md §11/§12) — the
+// per-source half of a destination assignment: Loki labels (loki destinations
+// only), field filters, parse templates (instance scope only) and the shipping
+// tunables. Used by the Servers-page RealmLogDestModal and the instance Logs
+// tab; the endpoint half (URL/TLS/auth) lives on /admin/log-destinations.
+
+/** Everything the shaping sub-form holds, as form-friendly strings. */
+export interface ShapingDraft {
+    job: string
+    hostLabel: string
+    statusLabel: string
+    extraLabels: string
+    filterText: string
+    parseText: string
+    sample: string
+    batchSize: string
+    flushInterval: string
+    maxRetries: string
+    bufferSize: string
+}
+
+export const emptyShapingDraft = (scope: 'realm' | 'instance'): ShapingDraft => ({
+    job: 'nginx',
+    hostLabel: scope === 'realm' ? '$resource' : 'none',
+    statusLabel: scope === 'realm' ? '$status' : 'none',
+    extraLabels: '',
+    filterText: '',
+    parseText: '',
+    sample: '',
+    batchSize: '',
+    flushInterval: '',
+    maxRetries: '',
+    bufferSize: '',
+})
+
+/** Reconstruct an editing draft from a stored binding's shaping. */
+export function shapingDraftOf(s: LogShaping): ShapingDraft {
+    const labels = s.labels ?? {}
+    const extraLabels = Object.entries(labels)
+        .filter(([k]) => k !== 'job' && k !== 'host' && k !== 'status_code')
+        .map(([k, v]) => `${k}=${v}`)
+        .join('\n')
+    const filterText = Object.entries(s.filter ?? {})
+        .map(([field, list]) => `${field}: ${list.join(', ')}`)
+        .join('\n')
+    return {
+        job: labels.job ?? 'nginx',
+        hostLabel: labels.host ?? 'none',
+        statusLabel: labels.status_code ?? 'none',
+        extraLabels,
+        filterText,
+        parseText: (s.parse ?? []).join('\n'),
+        sample: s.sample !== undefined ? String(s.sample) : '',
+        batchSize: s.batch_size !== undefined ? String(s.batch_size) : '',
+        flushInterval: s.flush_interval ?? '',
+        maxRetries: s.max_retries !== undefined ? String(s.max_retries) : '',
+        bufferSize: s.buffer_size !== undefined ? String(s.buffer_size) : '',
+    }
+}
+
+const numOr = (raw: string): number | undefined => {
+    const t = raw.trim()
+    if (t === '') return undefined
+    const n = Number(t)
+    return Number.isFinite(n) ? n : undefined
+}
+
+/** Assemble the API `shaping` payload from the draft, including only fields relevant to scope/type. */
+export function buildShapingPayload(
+    d: ShapingDraft,
+    opts: { scope: 'realm' | 'instance'; loki: boolean },
+): Record<string, unknown> {
+    const shaping: Record<string, unknown> = {}
+
+    if (opts.loki) {
+        const labels: Record<string, string> = {}
+        if (d.job.trim()) labels.job = d.job.trim()
+        if (d.hostLabel !== 'none') labels.host = d.hostLabel
+        if (d.statusLabel !== 'none') labels.status_code = d.statusLabel
+        for (const line of d.extraLabels.split('\n')) {
+            const trimmed = line.trim()
+            if (!trimmed) continue
+            const m = trimmed.match(/^([^=:]+)[=:]\s*(.+)$/)
+            if (m) labels[m[1].trim()] = m[2].trim()
+        }
+        if (Object.keys(labels).length) shaping.labels = labels
+    }
+
+    const filter: Record<string, string[]> = {}
+    for (const line of d.filterText.split('\n')) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        const idx = trimmed.indexOf(':')
+        if (idx < 0) continue
+        const field = trimmed.slice(0, idx).trim()
+        const matchers = trimmed
+            .slice(idx + 1)
+            .split(',')
+            .map((m) => m.trim())
+            .filter(Boolean)
+        if (field && matchers.length) filter[field] = matchers
+    }
+    if (Object.keys(filter).length) shaping.filter = filter
+
+    if (opts.scope === 'instance') {
+        const templates = d.parseText
+            .split('\n')
+            .map((l) => l.trim())
+            .filter(Boolean)
+        if (templates.length) shaping.parse = templates
+    }
+
+    if (numOr(d.sample) !== undefined) shaping.sample = numOr(d.sample)
+    if (numOr(d.batchSize) !== undefined) shaping.batch_size = numOr(d.batchSize)
+    if (numOr(d.maxRetries) !== undefined) shaping.max_retries = numOr(d.maxRetries)
+    if (numOr(d.bufferSize) !== undefined) shaping.buffer_size = numOr(d.bufferSize)
+    if (d.flushInterval.trim()) shaping.flush_interval = d.flushInterval.trim()
+
+    return shaping
+}
+
+/** Live LogQL preview from the current draft's label config (loki only). */
+export function draftLogql(d: ShapingDraft): string {
+    const parts = [`job="${d.job.trim() || 'nginx'}"`]
+    if (d.hostLabel !== 'none') parts.push('host=~".+"')
+    if (d.statusLabel !== 'none') parts.push('status_code=~".+"')
+    for (const line of d.extraLabels.split('\n')) {
+        const m = line.trim().match(/^([^=:]+)[=:]\s*(.+)$/)
+        if (m) parts.push(`${m[1].trim()}="${m[2].trim()}"`)
+    }
+    return `{${parts.join(', ')}}`
+}
+
+/** The shaping FormGroups — dropped into a FormModal after the destination select. */
+export function ShapingFields({
+    draft,
+    onPatch,
+    scope,
+    loki,
+}: {
+    draft: ShapingDraft
+    onPatch: (p: Partial<ShapingDraft>) => void
+    scope: 'realm' | 'instance'
+    loki: boolean
+}) {
+    return (
+        <>
+            {loki && (
+                <FormGroup title="Loki labels">
+                    <TextField
+                        label="job"
+                        placeholder="nginx"
+                        help="Static label (default nginx)."
+                        value={draft.job}
+                        onValue={(v) => onPatch({ job: v })}
+                    />
+                    <SelectField
+                        label="host label"
+                        help="$resource is bounded + recommended; $host is unsafe under wildcard vhosts."
+                        value={draft.hostLabel}
+                        options={[
+                            { value: 'none', label: 'No host label' },
+                            { value: '$resource', label: '$resource (entity name — recommended)' },
+                            { value: '$host', label: '$host (client Host header)' },
+                            { value: '$server_name', label: '$server_name' },
+                        ]}
+                        onValue={(v) => onPatch({ hostLabel: v })}
+                    />
+                    <SelectField
+                        label="status_code label"
+                        value={draft.statusLabel}
+                        options={[
+                            { value: 'none', label: 'No status label' },
+                            { value: '$status', label: '$status (exact code)' },
+                            { value: '$status_class', label: '$status_class (4xx / 5xx)' },
+                        ]}
+                        onValue={(v) => onPatch({ statusLabel: v })}
+                    />
+                    <TextAreaField
+                        label="Extra static labels"
+                        rows={2}
+                        placeholder={'region=eu\nenv=prod'}
+                        help="One key=value per line (static only, max 5)."
+                        value={draft.extraLabels}
+                        onValue={(v) => onPatch({ extraLabels: v })}
+                    />
+                    <p className="quaykeeper-admin-hint">
+                        Selector: <span className="quaykeeper-admin-mono">{draftLogql(draft)}</span>
+                    </p>
+                </FormGroup>
+            )}
+
+            <FormGroup title="Filter">
+                <TextAreaField
+                    label="Field matchers"
+                    rows={4}
+                    placeholder={'status: 4xx, 5xx\npath: !/healthz, !/metrics\nmethod: GET, POST'}
+                    help="One field per line: field: matcher, matcher. AND across lines, OR within a line. Fields: host, resource, path, user_agent, status, method, scheme, resource_type. Leading ! negates."
+                    value={draft.filterText}
+                    onValue={(v) => onPatch({ filterText: v })}
+                />
+            </FormGroup>
+
+            {scope === 'instance' && (
+                <FormGroup title="Parse templates">
+                    <TextAreaField
+                        label="Plain-text → structured"
+                        rows={3}
+                        placeholder={'{level} | {time} - {message}'}
+                        help="One template per line. A non-JSON log line matching a template becomes structured JSON (e.g. info | 12:20 - hi → {level,time,message}), so level/status filters and Loki labels work. First match wins; non-matching lines ship raw."
+                        value={draft.parseText}
+                        onValue={(v) => onPatch({ parseText: v })}
+                    />
+                </FormGroup>
+            )}
+
+            <FormGroup title="Shipping (optional)">
+                <TextField label="Sample (0–1]" placeholder="1.0" value={draft.sample} onValue={(v) => onPatch({ sample: v })} />
+                <TextField label="Batch size" type="number" placeholder="500" value={draft.batchSize} onValue={(v) => onPatch({ batchSize: v })} />
+                <TextField label="Flush interval" placeholder="2s" value={draft.flushInterval} onValue={(v) => onPatch({ flushInterval: v })} />
+                <TextField label="Max retries" type="number" placeholder="3" value={draft.maxRetries} onValue={(v) => onPatch({ maxRetries: v })} />
+                <TextField label="Buffer size (entries)" type="number" placeholder="8192" value={draft.bufferSize} onValue={(v) => onPatch({ bufferSize: v })} />
+            </FormGroup>
+        </>
+    )
+}

--- a/quaykeeper/components/admin/AdminLogDestinations.tsx
+++ b/quaykeeper/components/admin/AdminLogDestinations.tsx
@@ -1,21 +1,24 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { AdvancedTableColumn } from '@toolcase/web-components'
 import { iconBtnHtml } from '@/lib/action-icons'
 import { escapeHtml, useTc } from '@/lib/tc'
 import { AdminPage, json, useOwnerData } from './shared'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { FormModal, FormGroup } from '@/components/FormModal'
-import { SelectField, SwitchField, TextAreaField, TextField } from '@/components/fields'
+import { SelectField, SwitchField, TextField } from '@/components/fields'
 import { useToast } from '@/components/Toast'
 
-// Owner-only log-shipping destinations (log_ides.md §4). Each row is one push/sink
-// target for nginxpilot's structured access logs: Loki, a generic HTTP collector, a
-// local NDJSON file, or the container's stdout. Owner-only because every destination
-// carries a URL and the pipeline egresses log data (SSRF surface on test, G21).
-// Secrets are BY REFERENCE ONLY — auth carries an env-var / file NAME the operator
-// provisions on the nginxpilot host; Quaykeeper never holds the credential.
+// Owner-only reusable log endpoints (logs_feature.md §10). Each row is one push
+// target — Loki or a generic HTTP collector — defined ONCE and assigned to log
+// sources elsewhere: an NGINX server binds it from the Servers page, an instance
+// from its Logs tab. The binding carries the shaping (labels/filter/parse/
+// tunables); this page is purely the connection half. Owner-only because every
+// destination carries a URL and the pipeline egresses log data (SSRF surface on
+// test, G21). Secrets are BY REFERENCE ONLY — auth carries an env-var / file
+// NAME the operator provisions on the shipping host; Quaykeeper never holds the
+// credential.
 
 // ── local DTO shapes (mirror the /api/admin/log-destinations responses) ─────────
 
@@ -28,103 +31,57 @@ interface LogAuthSpec {
     token_file?: string
 }
 
-interface LogDestSpec {
+interface EndpointSpec {
     name: string
-    type: 'loki' | 'http' | 'file' | 'stdout'
-    enabled?: boolean
-    url?: string
+    type: 'loki' | 'http'
+    url: string
     tenant?: string
-    allow_insecure?: boolean
     ca_file?: string
+    allow_insecure?: boolean
     insecure_skip_verify?: boolean
     auth?: LogAuthSpec
-    labels?: Record<string, string>
-    filter?: Record<string, string[]>
-    parse?: string[]
-    sample?: number
-    batch_size?: number
-    flush_interval?: string
-    max_retries?: number
-    buffer_size?: number
-    path?: string
-    max_size?: string
-    max_files?: number
 }
 
 interface LogDestDto {
     id: string
     name: string
     type: string
-    scope: 'global' | 'instance'
-    target?: string
-    enabled: boolean
-    spec: LogDestSpec
-    logql: string
+    spec: EndpointSpec
+    usedBy: { realms: number; instances: number }
     createdAt: string
     updatedAt: string
-}
-
-interface LogDestLiveStat {
-    name: string
-    shipped: number
-    dropped: number
-    failed_batches: number
-    buffer_len: number
-    last_error?: string
-    last_flush?: string
-    oldest_buffered?: string
-}
-
-interface LogsStatus {
-    enabled: boolean
-    syslog_listen: string
-    intake_error?: string
-    received: number
-    parse_errors: number
-    destinations: LogDestLiveStat[]
 }
 
 // ── table rendering ─────────────────────────────────────────────────────────────
 
 const DEST_COLUMNS: AdvancedTableColumn[] = [
     { key: 'identity', label: 'Destination' },
-    { key: 'shipping', label: 'Shipping' },
+    { key: 'usedBy', label: 'Used by' },
     { key: 'actions', label: '', align: 'right' },
 ]
 
-function healthDot(dto: LogDestDto, stat: LogDestLiveStat | undefined): { cls: string; title: string } {
-    if (!dto.enabled) return { cls: 'quaykeeper-realm-dot--unknown', title: 'Disabled' }
-    if (dto.scope === 'instance') return { cls: 'quaykeeper-realm-dot--unknown', title: 'Delivered to instances (client-side shipping)' }
-    if (!stat) return { cls: 'quaykeeper-realm-dot--unknown', title: 'No shipping stats yet' }
-    if (stat.last_error) return { cls: 'quaykeeper-realm-dot--down', title: stat.last_error }
-    return { cls: 'quaykeeper-realm-dot--ok', title: stat.last_flush ? `Last flush ${stat.last_flush}` : 'Healthy' }
-}
-
-interface DestRow {
-    dto: LogDestDto
-    stat: LogDestLiveStat | undefined
+/** "2 servers · 1 instance" — the at-a-glance reuse signal (D4). */
+function usedByText(dto: LogDestDto): string {
+    const parts: string[] = []
+    if (dto.usedBy.realms > 0) parts.push(`${dto.usedBy.realms} server${dto.usedBy.realms === 1 ? '' : 's'}`)
+    if (dto.usedBy.instances > 0) parts.push(`${dto.usedBy.instances} instance${dto.usedBy.instances === 1 ? '' : 's'}`)
+    return parts.length ? parts.join(' · ') : 'unbound'
 }
 
 /** The injected `<tbody>` HTML — every interpolated value is escaped. */
-function destRowsHtml(rows: DestRow[], busy: boolean): string {
-    return rows
-        .map(({ dto, stat }) => {
-            const { cls, title } = healthDot(dto, stat)
-
+function destRowsHtml(dests: LogDestDto[], busy: boolean): string {
+    return dests
+        .map((dto) => {
             const badges: string[] = [`<span class="badge text-bg-info">${escapeHtml(dto.type)}</span>`]
-            badges.push(`<span class="badge text-bg-secondary">${escapeHtml(dto.scope)}</span>`)
-            if (!dto.enabled) badges.push('<span class="badge text-bg-light">disabled</span>')
-            if (dto.target) badges.push(`<span class="badge text-bg-light">${escapeHtml(dto.target)}</span>`)
+            if (dto.spec.allow_insecure) badges.push('<span class="badge text-bg-warning">insecure</span>')
+            if (dto.spec.auth?.method && dto.spec.auth.method !== 'none') {
+                badges.push(`<span class="badge text-bg-light">${escapeHtml(dto.spec.auth.method)} auth</span>`)
+            }
 
-            const sub = dto.type === 'loki' && dto.logql
-                ? escapeHtml(dto.logql)
-                : escapeHtml(dto.spec.url || dto.spec.path || (dto.type === 'stdout' ? 'container stdout' : ''))
-
-            const shipping = stat
-                ? `<span class="quaykeeper-admin-hint">↑ ${stat.shipped.toLocaleString()} · ✕ ${stat.dropped.toLocaleString()} · ⚠ ${stat.failed_batches.toLocaleString()}${stat.buffer_len ? ` · buf ${stat.buffer_len}` : ''}</span>`
-                : dto.scope === 'instance'
-                  ? '<span class="quaykeeper-admin-hint">client-side</span>'
-                  : '<span class="quaykeeper-admin-hint">—</span>'
+            const bound = dto.usedBy.realms + dto.usedBy.instances > 0
+            const usedBy = bound
+                ? `<span class="quaykeeper-admin-hint">${escapeHtml(usedByText(dto))}</span>`
+                : '<span class="quaykeeper-admin-hint">—</span>'
 
             const controls = [
                 iconBtnHtml({ icon: 'test', label: `Test ${dto.name}`, data: { action: 'test', id: dto.id } }),
@@ -141,12 +98,11 @@ function destRowsHtml(rows: DestRow[], busy: boolean): string {
             return (
                 `<tr>` +
                 `<td><span class="quaykeeper-admin-realm-id">` +
-                `<span class="quaykeeper-realm-dot ${cls}" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}"></span>` +
                 `<span class="quaykeeper-admin-realm-name">${escapeHtml(dto.name)}</span>` +
-                `<span class="quaykeeper-admin-mono quaykeeper-admin-hint">${sub}</span>` +
+                `<span class="quaykeeper-admin-mono quaykeeper-admin-hint">${escapeHtml(dto.spec.url)}</span>` +
                 `<span class="quaykeeper-admin-badges">${badges.join('')}</span>` +
                 `</span></td>` +
-                `<td>${shipping}</td>` +
+                `<td>${usedBy}</td>` +
                 `<td class="text-end"><span class="quaykeeper-admin-domain-controls">${controls}</span></td>` +
                 `</tr>`
             )
@@ -167,7 +123,7 @@ export function AdminLogDestinations() {
     return (
         <AdminPage
             title="Log destinations"
-            subtitle="Where nginxpilot ships its structured access logs — Loki, a generic HTTP collector, a local file, or stdout. Multi-field filters and Loki label config included. Owner-only; secrets are provisioned on the nginxpilot host and referenced by name."
+            subtitle="Reusable log endpoints. Assign them to an NGINX server (Servers page) or an instance (its Logs tab). Owner-only; secrets are referenced by name, never stored."
             icon="scroll-text"
             iconColor="violet"
             state={state}
@@ -178,14 +134,11 @@ export function AdminLogDestinations() {
     )
 }
 
-// ── the create/edit form ─────────────────────────────────────────────────────────
+// ── the create/edit form (endpoint fields only) ──────────────────────────────────
 
 interface Draft {
     name: string
     type: string
-    scope: string
-    target: string
-    enabled: boolean
     url: string
     tenant: string
     allowInsecure: boolean
@@ -197,28 +150,11 @@ interface Draft {
     passwordFile: string
     tokenEnv: string
     tokenFile: string
-    job: string
-    hostLabel: string
-    statusLabel: string
-    extraLabels: string
-    filterText: string
-    parseText: string
-    sample: string
-    batchSize: string
-    flushInterval: string
-    maxRetries: string
-    bufferSize: string
-    path: string
-    maxSize: string
-    maxFiles: string
 }
 
 const emptyDraft = (): Draft => ({
     name: '',
     type: 'loki',
-    scope: 'global',
-    target: '',
-    enabled: true,
     url: '',
     tenant: '',
     allowInsecure: false,
@@ -230,40 +166,14 @@ const emptyDraft = (): Draft => ({
     passwordFile: '',
     tokenEnv: '',
     tokenFile: '',
-    job: 'nginx',
-    hostLabel: '$resource',
-    statusLabel: '$status',
-    extraLabels: '',
-    filterText: '',
-    parseText: '',
-    sample: '',
-    batchSize: '',
-    flushInterval: '',
-    maxRetries: '',
-    bufferSize: '',
-    path: '',
-    maxSize: '',
-    maxFiles: '',
 })
 
-/** Reconstruct an editing draft from a stored destination's spec. */
+/** Reconstruct an editing draft from a stored endpoint spec. */
 function draftOf(dto: LogDestDto): Draft {
     const s = dto.spec
-    const labels = s.labels ?? {}
-    const extraLabels = Object.entries(labels)
-        .filter(([k]) => k !== 'job' && k !== 'host' && k !== 'status_code')
-        .map(([k, v]) => `${k}=${v}`)
-        .join('\n')
-    const filterText = Object.entries(s.filter ?? {})
-        .map(([field, list]) => `${field}: ${list.join(', ')}`)
-        .join('\n')
-    const parseText = (s.parse ?? []).join('\n')
     return {
         name: s.name,
         type: s.type,
-        scope: dto.scope,
-        target: dto.target ?? '',
-        enabled: dto.enabled,
         url: s.url ?? '',
         tenant: s.tenant ?? '',
         allowInsecure: s.allow_insecure ?? false,
@@ -275,124 +185,33 @@ function draftOf(dto: LogDestDto): Draft {
         passwordFile: s.auth?.password_file ?? '',
         tokenEnv: s.auth?.token_env ?? '',
         tokenFile: s.auth?.token_file ?? '',
-        job: labels.job ?? 'nginx',
-        hostLabel: labels.host ?? 'none',
-        statusLabel: labels.status_code ?? 'none',
-        extraLabels,
-        filterText,
-        parseText,
-        sample: s.sample !== undefined ? String(s.sample) : '',
-        batchSize: s.batch_size !== undefined ? String(s.batch_size) : '',
-        flushInterval: s.flush_interval ?? '',
-        maxRetries: s.max_retries !== undefined ? String(s.max_retries) : '',
-        bufferSize: s.buffer_size !== undefined ? String(s.buffer_size) : '',
-        path: s.path ?? '',
-        maxSize: s.max_size ?? '',
-        maxFiles: s.max_files !== undefined ? String(s.max_files) : '',
     }
 }
 
-const numOr = (raw: string): number | undefined => {
-    const t = raw.trim()
-    if (t === '') return undefined
-    const n = Number(t)
-    return Number.isFinite(n) ? n : undefined
-}
-
-/** Assemble the API payload from the draft, including only fields relevant to the type. */
+/** Assemble the endpoint API payload from the draft. */
 function buildPayload(d: Draft): Record<string, unknown> {
-    const isPush = d.type === 'loki' || d.type === 'http'
     const payload: Record<string, unknown> = {
         name: d.name.trim(),
         type: d.type,
-        scope: d.scope,
-        enabled: d.enabled,
+        url: d.url.trim(),
     }
-    if (d.scope === 'instance' && d.target.trim()) payload.target = d.target.trim()
-
-    // parse templates — instance scope only (nginxpilot access logs are already JSON).
-    if (d.scope === 'instance') {
-        const templates = d.parseText
-            .split('\n')
-            .map((l) => l.trim())
-            .filter(Boolean)
-        if (templates.length) payload.parse = templates
-    }
-
-    // filter (all types)
-    const filter: Record<string, string[]> = {}
-    for (const line of d.filterText.split('\n')) {
-        const trimmed = line.trim()
-        if (!trimmed) continue
-        const idx = trimmed.indexOf(':')
-        if (idx < 0) continue
-        const field = trimmed.slice(0, idx).trim()
-        const matchers = trimmed
-            .slice(idx + 1)
-            .split(',')
-            .map((m) => m.trim())
-            .filter(Boolean)
-        if (field && matchers.length) filter[field] = matchers
-    }
-    if (Object.keys(filter).length) payload.filter = filter
-
-    // shipping tunables (all types)
-    if (numOr(d.sample) !== undefined) payload.sample = numOr(d.sample)
-    if (numOr(d.batchSize) !== undefined) payload.batch_size = numOr(d.batchSize)
-    if (numOr(d.maxRetries) !== undefined) payload.max_retries = numOr(d.maxRetries)
-    if (numOr(d.bufferSize) !== undefined) payload.buffer_size = numOr(d.bufferSize)
-    if (d.flushInterval.trim()) payload.flush_interval = d.flushInterval.trim()
-
-    if (isPush) {
-        payload.url = d.url.trim()
-        if (d.allowInsecure) payload.allow_insecure = true
-        if (d.caFile.trim()) payload.ca_file = d.caFile.trim()
-        if (d.insecureSkipVerify) payload.insecure_skip_verify = true
-        if (d.authMethod !== 'none') {
-            const auth: Record<string, string> = { method: d.authMethod }
-            if (d.authMethod === 'basic') {
-                auth.username = d.username.trim()
-                if (d.passwordEnv.trim()) auth.password_env = d.passwordEnv.trim()
-                if (d.passwordFile.trim()) auth.password_file = d.passwordFile.trim()
-            } else {
-                if (d.tokenEnv.trim()) auth.token_env = d.tokenEnv.trim()
-                if (d.tokenFile.trim()) auth.token_file = d.tokenFile.trim()
-            }
-            payload.auth = auth
+    if (d.allowInsecure) payload.allow_insecure = true
+    if (d.caFile.trim()) payload.ca_file = d.caFile.trim()
+    if (d.insecureSkipVerify) payload.insecure_skip_verify = true
+    if (d.type === 'loki' && d.tenant.trim()) payload.tenant = d.tenant.trim()
+    if (d.authMethod !== 'none') {
+        const auth: Record<string, string> = { method: d.authMethod }
+        if (d.authMethod === 'basic') {
+            auth.username = d.username.trim()
+            if (d.passwordEnv.trim()) auth.password_env = d.passwordEnv.trim()
+            if (d.passwordFile.trim()) auth.password_file = d.passwordFile.trim()
+        } else {
+            if (d.tokenEnv.trim()) auth.token_env = d.tokenEnv.trim()
+            if (d.tokenFile.trim()) auth.token_file = d.tokenFile.trim()
         }
-        if (d.type === 'loki') {
-            if (d.tenant.trim()) payload.tenant = d.tenant.trim()
-            const labels: Record<string, string> = {}
-            if (d.job.trim()) labels.job = d.job.trim()
-            if (d.hostLabel !== 'none') labels.host = d.hostLabel
-            if (d.statusLabel !== 'none') labels.status_code = d.statusLabel
-            for (const line of d.extraLabels.split('\n')) {
-                const trimmed = line.trim()
-                if (!trimmed) continue
-                const m = trimmed.match(/^([^=:]+)[=:]\s*(.+)$/)
-                if (m) labels[m[1].trim()] = m[2].trim()
-            }
-            if (Object.keys(labels).length) payload.labels = labels
-        }
-    } else if (d.type === 'file') {
-        payload.path = d.path.trim()
-        if (d.maxSize.trim()) payload.max_size = d.maxSize.trim()
-        if (numOr(d.maxFiles) !== undefined) payload.max_files = numOr(d.maxFiles)
+        payload.auth = auth
     }
     return payload
-}
-
-/** Live LogQL preview from the current draft's label config (loki only). */
-function draftLogql(d: Draft): string {
-    if (d.type !== 'loki') return ''
-    const parts = [`job="${d.job.trim() || 'nginx'}"`]
-    if (d.hostLabel !== 'none') parts.push('host=~".+"')
-    if (d.statusLabel !== 'none') parts.push('status_code=~".+"')
-    for (const line of d.extraLabels.split('\n')) {
-        const m = line.trim().match(/^([^=:]+)[=:]\s*(.+)$/)
-        if (m) parts.push(`${m[1].trim()}="${m[2].trim()}"`)
-    }
-    return `{${parts.join(', ')}}`
 }
 
 function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () => void }) {
@@ -401,7 +220,6 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
     const [error, setError] = useState<string | null>(null)
     const [busy, setBusy] = useState(false)
     const [pending, setPending] = useState<LogDestDto | null>(null)
-    const [stats, setStats] = useState<Record<string, LogDestLiveStat>>({})
     const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
 
     const patchDraft = (p: Partial<Draft>) =>
@@ -412,26 +230,6 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
         setError(null)
         setTestResult(null)
     }, [])
-
-    // Poll the daemon's per-destination shipping stats and index them by name.
-    const loadStats = useCallback(async () => {
-        try {
-            const res = await fetch('/api/admin/log-destinations/status', { cache: 'no-store' })
-            if (!res.ok) return
-            const body = (await res.json()) as LogsStatus
-            const byName: Record<string, LogDestLiveStat> = {}
-            for (const s of body.destinations ?? []) byName[s.name] = s
-            setStats(byName)
-        } catch {
-            // best-effort — the table still renders without live stats
-        }
-    }, [])
-
-    useEffect(() => {
-        void loadStats()
-        const t = setInterval(() => void loadStats(), 5000)
-        return () => clearInterval(t)
-    }, [loadStats])
 
     const runTest = useCallback(async (draft: Draft): Promise<void> => {
         setTestResult(null)
@@ -455,6 +253,10 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
         const d = form.draft
         if (!d.name.trim()) {
             setError('A destination needs a name.')
+            return
+        }
+        if (!d.url.trim()) {
+            setError('A destination needs a URL.')
             return
         }
         setBusy(true)
@@ -504,7 +306,13 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
         try {
             const res = await fetch(`/api/admin/log-destinations/${encodeURIComponent(dto.id)}`, { method: 'DELETE' })
             if (!res.ok && res.status !== 204) {
-                setError(`Couldn’t remove ${dto.name} (error ${res.status}).`)
+                const body = (await res.json().catch(() => null)) as { error?: string } | null
+                const bindings = dto.usedBy.realms + dto.usedBy.instances
+                setError(
+                    body?.error === 'destination_in_use'
+                        ? `“${dto.name}” is in use by ${bindings} binding${bindings === 1 ? '' : 's'} — unbind first.`
+                        : `Couldn’t remove ${dto.name} (error ${res.status}).`,
+                )
                 return
             }
             toast.show(`Destination “${dto.name}” removed.`, { variant: 'success' })
@@ -516,7 +324,6 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
         }
     }, [pending, busy, onChanged, toast])
 
-    const rows = useMemo<DestRow[]>(() => dests.map((dto) => ({ dto, stat: stats[dto.name] })), [dests, stats])
     const editing = form?.id ? dests.find((s) => s.id === form.id) : undefined
 
     const onDelegated = useCallback(
@@ -544,27 +351,26 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
     const tableProps = useMemo(
         () => ({
             columns: DEST_COLUMNS,
-            total: rows.length,
-            limit: rows.length || 10,
+            total: dests.length,
+            limit: dests.length || 10,
             offset: 0,
-            rows: destRowsHtml(rows, busy),
+            rows: destRowsHtml(dests, busy),
         }),
-        [rows, busy],
+        [dests, busy],
     )
     const tableRef = useTc<HTMLElement>(tableProps, { click: onDelegated })
 
     const d = form?.draft
-    const isPush = d?.type === 'loki' || d?.type === 'http'
 
     return (
         <>
             <tc-section-card title="Log destinations" icon="scroll-text">
                 <div className="quaykeeper-admin-section">
                     <p className="quaykeeper-home-lead quaykeeper-admin-hint">
-                        Global destinations are pushed to the active NGINX server and ship its access logs directly to the
-                        target (Quaykeeper only distributes the config, never the log bytes). Instance destinations are
-                        delivered to quaykeeper-client for app-log shipping. Credentials are referenced by env-var / file name
-                        and provisioned on the host — never stored here.
+                        A destination is a reusable endpoint — URL, TLS and auth only. What gets shipped to it, and how,
+                        is set where it’s assigned: on an NGINX server (Servers page → log destination) for access logs,
+                        or on an instance’s Logs tab for app logs. Credentials are referenced by env-var / file name and
+                        provisioned on the shipping host — never stored here.
                     </p>
                     {error && !form && <tc-banner variant="danger">{error}</tc-banner>}
 
@@ -608,224 +414,96 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
                             options={[
                                 { value: 'loki', label: 'Loki (push API)' },
                                 { value: 'http', label: 'HTTP collector (NDJSON)' },
-                                { value: 'file', label: 'Local file (NDJSON, self-rotating)' },
-                                { value: 'stdout', label: 'stdout (container log stream)' },
                             ]}
                             onValue={(v) => patchDraft({ type: v })}
                         />
-                        <SelectField
-                            label="Scope"
-                            help="global → pushed to the NGINX edge. instance → delivered to quaykeeper-client for app logs."
-                            value={d.scope}
-                            options={[
-                                { value: 'global', label: 'Global (NGINX edge)' },
-                                { value: 'instance', label: 'Instance (app logs)' },
-                            ]}
-                            onValue={(v) => patchDraft({ scope: v })}
+                    </FormGroup>
+
+                    <FormGroup title="Endpoint">
+                        <TextField
+                            label="URL"
+                            placeholder={d.type === 'loki' ? 'https://loki.example.com/loki/api/v1/push' : 'https://collector.example.com/ingest'}
+                            help="https:// required unless you enable allow-insecure."
+                            value={d.url}
+                            onValue={(v) => patchDraft({ url: v })}
                         />
-                        {d.scope === 'instance' && (
+                        {d.type === 'loki' && (
                             <TextField
-                                label="Target instance"
-                                placeholder="inst_…"
-                                help="The Config instance id this destination is delivered to."
-                                value={d.target}
-                                onValue={(v) => patchDraft({ target: v })}
+                                label="Tenant"
+                                placeholder="infra"
+                                help="Optional Loki X-Scope-OrgID."
+                                value={d.tenant}
+                                onValue={(v) => patchDraft({ tenant: v })}
                             />
                         )}
-                        <SwitchField label="Enabled" checked={d.enabled} onChecked={(v) => patchDraft({ enabled: v })} />
-                    </FormGroup>
-
-                    {isPush && (
-                        <FormGroup title="Endpoint">
-                            <TextField
-                                label="URL"
-                                placeholder={d.type === 'loki' ? 'https://loki.example.com/loki/api/v1/push' : 'https://collector.example.com/ingest'}
-                                help="https:// required unless you enable allow-insecure."
-                                value={d.url}
-                                onValue={(v) => patchDraft({ url: v })}
-                            />
-                            {d.type === 'loki' && (
-                                <TextField
-                                    label="Tenant"
-                                    placeholder="infra"
-                                    help="Optional Loki X-Scope-OrgID."
-                                    value={d.tenant}
-                                    onValue={(v) => patchDraft({ tenant: v })}
-                                />
-                            )}
-                            <TextField
-                                label="CA file"
-                                placeholder="/etc/nginxpilot/loki-ca.pem"
-                                help="Optional — trust a private CA (daemon-local path)."
-                                value={d.caFile}
-                                onValue={(v) => patchDraft({ caFile: v })}
-                            />
-                            <SwitchField
-                                label="Allow insecure (http:// / skip verify)"
-                                checked={d.allowInsecure}
-                                onChecked={(v) => patchDraft({ allowInsecure: v })}
-                            />
-                            {d.allowInsecure && (
-                                <SwitchField
-                                    label="Skip TLS verification"
-                                    checked={d.insecureSkipVerify}
-                                    onChecked={(v) => patchDraft({ insecureSkipVerify: v })}
-                                />
-                            )}
-                        </FormGroup>
-                    )}
-
-                    {isPush && (
-                        <FormGroup title="Auth (by reference)">
-                            <SelectField
-                                label="Method"
-                                value={d.authMethod}
-                                options={[
-                                    { value: 'none', label: 'None' },
-                                    { value: 'basic', label: 'Basic' },
-                                    { value: 'bearer', label: 'Bearer' },
-                                ]}
-                                onValue={(v) => patchDraft({ authMethod: v })}
-                            />
-                            {d.authMethod === 'basic' && (
-                                <>
-                                    <TextField label="Username" value={d.username} onValue={(v) => patchDraft({ username: v })} />
-                                    <TextField
-                                        label="Password env var"
-                                        placeholder="LOKI_PASSWORD"
-                                        help="Name of the env var on the nginxpilot host — never the value."
-                                        value={d.passwordEnv}
-                                        onValue={(v) => patchDraft({ passwordEnv: v })}
-                                    />
-                                    <TextField
-                                        label="…or password file"
-                                        placeholder="/run/secrets/loki_password"
-                                        help="Daemon-local file path (re-read per flush; rotate-safe)."
-                                        value={d.passwordFile}
-                                        onValue={(v) => patchDraft({ passwordFile: v })}
-                                    />
-                                </>
-                            )}
-                            {d.authMethod === 'bearer' && (
-                                <>
-                                    <TextField
-                                        label="Token env var"
-                                        placeholder="COLLECTOR_TOKEN"
-                                        help="Name of the env var on the host — never the value."
-                                        value={d.tokenEnv}
-                                        onValue={(v) => patchDraft({ tokenEnv: v })}
-                                    />
-                                    <TextField
-                                        label="…or token file"
-                                        placeholder="/run/secrets/collector_token"
-                                        value={d.tokenFile}
-                                        onValue={(v) => patchDraft({ tokenFile: v })}
-                                    />
-                                </>
-                            )}
-                        </FormGroup>
-                    )}
-
-                    {d.type === 'loki' && (
-                        <FormGroup title="Loki labels">
-                            <TextField
-                                label="job"
-                                placeholder="nginx"
-                                help="Static label (default nginx)."
-                                value={d.job}
-                                onValue={(v) => patchDraft({ job: v })}
-                            />
-                            <SelectField
-                                label="host label"
-                                help="$resource is bounded + recommended; $host is unsafe under wildcard vhosts."
-                                value={d.hostLabel}
-                                options={[
-                                    { value: 'none', label: 'No host label' },
-                                    { value: '$resource', label: '$resource (entity name — recommended)' },
-                                    { value: '$host', label: '$host (client Host header)' },
-                                    { value: '$server_name', label: '$server_name' },
-                                ]}
-                                onValue={(v) => patchDraft({ hostLabel: v })}
-                            />
-                            <SelectField
-                                label="status_code label"
-                                value={d.statusLabel}
-                                options={[
-                                    { value: 'none', label: 'No status label' },
-                                    { value: '$status', label: '$status (exact code)' },
-                                    { value: '$status_class', label: '$status_class (4xx / 5xx)' },
-                                ]}
-                                onValue={(v) => patchDraft({ statusLabel: v })}
-                            />
-                            <TextAreaField
-                                label="Extra static labels"
-                                rows={2}
-                                placeholder={'region=eu\nenv=prod'}
-                                help="One key=value per line (static only, max 5)."
-                                value={d.extraLabels}
-                                onValue={(v) => patchDraft({ extraLabels: v })}
-                            />
-                            <p className="quaykeeper-admin-hint">
-                                Selector: <span className="quaykeeper-admin-mono">{draftLogql(d)}</span>
-                            </p>
-                        </FormGroup>
-                    )}
-
-                    {d.type === 'file' && (
-                        <FormGroup title="File">
-                            <TextField
-                                label="Path"
-                                placeholder="/var/log/nginxpilot/access.ndjson"
-                                help="Absolute path. Self-rotates by size."
-                                value={d.path}
-                                onValue={(v) => patchDraft({ path: v })}
-                            />
-                            <TextField
-                                label="Max size"
-                                placeholder="64MiB"
-                                value={d.maxSize}
-                                onValue={(v) => patchDraft({ maxSize: v })}
-                            />
-                            <TextField
-                                label="Max files"
-                                type="number"
-                                placeholder="3"
-                                value={d.maxFiles}
-                                onValue={(v) => patchDraft({ maxFiles: v })}
-                            />
-                        </FormGroup>
-                    )}
-
-                    <FormGroup title="Filter">
-                        <TextAreaField
-                            label="Field matchers"
-                            rows={4}
-                            placeholder={'status: 4xx, 5xx\npath: !/healthz, !/metrics\nmethod: GET, POST'}
-                            help="One field per line: field: matcher, matcher. AND across lines, OR within a line. Fields: host, resource, path, user_agent, status, method, scheme, resource_type. Leading ! negates."
-                            value={d.filterText}
-                            onValue={(v) => patchDraft({ filterText: v })}
+                        <TextField
+                            label="CA file"
+                            placeholder="/etc/nginxpilot/loki-ca.pem"
+                            help="Optional — trust a private CA (daemon-local path)."
+                            value={d.caFile}
+                            onValue={(v) => patchDraft({ caFile: v })}
                         />
+                        <SwitchField
+                            label="Allow insecure (http:// / skip verify)"
+                            checked={d.allowInsecure}
+                            onChecked={(v) => patchDraft({ allowInsecure: v })}
+                        />
+                        {d.allowInsecure && (
+                            <SwitchField
+                                label="Skip TLS verification"
+                                checked={d.insecureSkipVerify}
+                                onChecked={(v) => patchDraft({ insecureSkipVerify: v })}
+                            />
+                        )}
                     </FormGroup>
 
-                    {d.scope === 'instance' && (
-                        <FormGroup title="Parse templates">
-                            <TextAreaField
-                                label="Plain-text → structured"
-                                rows={3}
-                                placeholder={'{level} | {time} - {message}'}
-                                help="One template per line. A non-JSON log line matching a template becomes structured JSON (e.g. info | 12:20 - hi → {level,time,message}), so level/status filters and Loki labels work. First match wins; non-matching lines ship raw."
-                                value={d.parseText}
-                                onValue={(v) => patchDraft({ parseText: v })}
-                            />
-                        </FormGroup>
-                    )}
-
-                    <FormGroup title="Shipping (optional)">
-                        <TextField label="Sample (0–1]" placeholder="1.0" value={d.sample} onValue={(v) => patchDraft({ sample: v })} />
-                        <TextField label="Batch size" type="number" placeholder="500" value={d.batchSize} onValue={(v) => patchDraft({ batchSize: v })} />
-                        <TextField label="Flush interval" placeholder="2s" value={d.flushInterval} onValue={(v) => patchDraft({ flushInterval: v })} />
-                        <TextField label="Max retries" type="number" placeholder="3" value={d.maxRetries} onValue={(v) => patchDraft({ maxRetries: v })} />
-                        <TextField label="Buffer size (entries)" type="number" placeholder="8192" value={d.bufferSize} onValue={(v) => patchDraft({ bufferSize: v })} />
+                    <FormGroup title="Auth (by reference)">
+                        <SelectField
+                            label="Method"
+                            value={d.authMethod}
+                            options={[
+                                { value: 'none', label: 'None' },
+                                { value: 'basic', label: 'Basic' },
+                                { value: 'bearer', label: 'Bearer' },
+                            ]}
+                            onValue={(v) => patchDraft({ authMethod: v })}
+                        />
+                        {d.authMethod === 'basic' && (
+                            <>
+                                <TextField label="Username" value={d.username} onValue={(v) => patchDraft({ username: v })} />
+                                <TextField
+                                    label="Password env var"
+                                    placeholder="LOKI_PASSWORD"
+                                    help="Name of the env var on the shipping host — never the value."
+                                    value={d.passwordEnv}
+                                    onValue={(v) => patchDraft({ passwordEnv: v })}
+                                />
+                                <TextField
+                                    label="…or password file"
+                                    placeholder="/run/secrets/loki_password"
+                                    help="Host-local file path (re-read per flush; rotate-safe)."
+                                    value={d.passwordFile}
+                                    onValue={(v) => patchDraft({ passwordFile: v })}
+                                />
+                            </>
+                        )}
+                        {d.authMethod === 'bearer' && (
+                            <>
+                                <TextField
+                                    label="Token env var"
+                                    placeholder="COLLECTOR_TOKEN"
+                                    help="Name of the env var on the host — never the value."
+                                    value={d.tokenEnv}
+                                    onValue={(v) => patchDraft({ tokenEnv: v })}
+                                />
+                                <TextField
+                                    label="…or token file"
+                                    placeholder="/run/secrets/collector_token"
+                                    value={d.tokenFile}
+                                    onValue={(v) => patchDraft({ tokenFile: v })}
+                                />
+                            </>
+                        )}
                     </FormGroup>
 
                     <FormGroup title="Test connection">
@@ -844,7 +522,7 @@ function LogDestForm({ dests, onChanged }: { dests: LogDestDto[]; onChanged: () 
                 title="Remove log destination?"
                 message={
                     pending
-                        ? `Remove ${pending.name}. Shipping stops immediately${pending.scope === 'global' ? ' and its fragment is retracted from the NGINX server' : ''}. Buffered entries are flushed best-effort.`
+                        ? `Remove ${pending.name}. Removal is blocked while any NGINX server or instance still binds it (currently: ${usedByText(pending)}).`
                         : undefined
                 }
                 confirmLabel="Remove"

--- a/quaykeeper/components/admin/AdminRealms.tsx
+++ b/quaykeeper/components/admin/AdminRealms.tsx
@@ -8,7 +8,15 @@ import type { Realm } from '@/server/domain/types'
 import { AdminPage, json, useOwnerData } from './shared'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { FormModal, FormGroup } from '@/components/FormModal'
-import { TextField } from '@/components/fields'
+import { SelectField, SwitchField, TextField } from '@/components/fields'
+import {
+    ShapingFields,
+    buildShapingPayload,
+    emptyShapingDraft,
+    shapingDraftOf,
+    type ShapingDraft,
+} from '@/components/LogShapingFields'
+import type { LogShaping } from '@/server/domain/nginxpilot-logdest-fragment'
 import { useToast } from '@/components/Toast'
 
 // Owner-only realm registry (multiple_realms.md §C). A realm is one registered nginxpilot
@@ -39,9 +47,42 @@ interface RealmTest {
 
 type RealmTestState = RealmTest | 'loading' | undefined
 
+/** One realm log binding as `/api/admin/realms/{id}/log-bindings` returns it. */
+interface LogBindingDto {
+    id: string
+    destinationId: string
+    destinationName: string
+    destinationType: string
+    destinationUrl: string
+    enabled: boolean
+    shaping: LogShaping
+    logql: string
+}
+
+/** Destination options for the binding select (`/api/admin/log-destinations`). */
+interface DestOption {
+    id: string
+    name: string
+    type: string
+    spec: { url: string }
+}
+
+/** One destination's live shipping stats (`/api/admin/log-destinations/status?realm=`). */
+interface LogDestLiveStat {
+    name: string
+    shipped: number
+    dropped: number
+    failed_batches: number
+    buffer_len: number
+    last_error?: string
+    last_flush?: string
+}
+
 interface RealmRow extends Record<string, unknown> {
     realm: Realm
     test: RealmTestState
+    /** The bound destination's name, when this realm ships its access logs somewhere. */
+    logDest: string | undefined
 }
 
 /** Health-dot class + title: green = ok, amber = reachable-but-status-failed OR
@@ -83,7 +124,7 @@ const REALM_COLUMNS: AdvancedTableColumn[] = [
 /** The injected `<tbody>` HTML — every interpolated value is escaped. */
 function realmRowsHtml(rows: RealmRow[], busy: boolean): string {
     return rows
-        .map(({ realm: r, test }) => {
+        .map(({ realm: r, test, logDest }) => {
             const { cls, title } = healthDotMeta(test)
 
             const badges: string[] = []
@@ -91,6 +132,7 @@ function realmRowsHtml(rows: RealmRow[], busy: boolean): string {
             badges.push(
                 `<span class="badge text-bg-${r.hasToken ? 'light' : 'secondary'}">${r.hasToken ? 'token set' : 'no token'}</span>`,
             )
+            if (logDest) badges.push(`<span class="badge text-bg-info">logs → ${escapeHtml(logDest)}</span>`)
             if (test && test !== 'loading') {
                 if (test.managed) badges.push('<span class="badge text-bg-info">managed</span>')
                 if (test.apiVersion)
@@ -115,6 +157,7 @@ function realmRowsHtml(rows: RealmRow[], busy: boolean): string {
                           }),
                       ]),
                 iconBtnHtml({ icon: 'rotate', label: `Rotate token for ${r.name}`, data: { action: 'rotate', id: r.id } }),
+                iconBtnHtml({ icon: 'logs', label: `Log destination for ${r.name}`, data: { action: 'logdest', id: r.id } }),
                 iconBtnHtml({
                     icon: 'remove',
                     label: `Remove ${r.name}`,
@@ -184,8 +227,12 @@ function RealmsForm({ realms, onChanged }: { realms: Realm[]; onChanged: () => v
     // The realm awaiting remove confirmation, and the realm whose token is being rotated.
     const [pending, setPending] = useState<Realm | null>(null)
     const [rotating, setRotating] = useState<string | null>(null)
+    // The realm whose log binding is being edited (the RealmLogDestModal).
+    const [logDestRealm, setLogDestRealm] = useState<string | null>(null)
     // Live health results, keyed by realm id (lazily filled by the test effect / button).
     const [tests, setTests] = useState<Record<string, RealmTest | 'loading'>>({})
+    // Each realm's log binding(s), keyed by realm id — drives the "logs → dest" badge.
+    const [bindings, setBindings] = useState<Record<string, LogBindingDto[]>>({})
 
     const patchDraft = (p: Partial<RealmDraft>) => setForm((prev) => (prev ? { ...prev, ...p } : prev))
 
@@ -218,11 +265,26 @@ function RealmsForm({ realms, onChanged }: { realms: Realm[]; onChanged: () => v
         }
     }, [])
 
-    // Auto health-check every realm once on mount / when the set changes.
+    const loadBindings = useCallback(async (id: string) => {
+        try {
+            const res = await fetch(`/api/admin/realms/${encodeURIComponent(id)}/log-bindings`, { cache: 'no-store' })
+            if (!res.ok) return
+            const list = (await res.json()) as LogBindingDto[]
+            setBindings((b) => ({ ...b, [id]: list }))
+        } catch {
+            // best-effort — the row simply renders without the logs badge
+        }
+    }, [])
+
+    // Auto health-check every realm once on mount / when the set changes, and load
+    // its log binding for the "logs → dest" badge.
     useEffect(() => {
-        for (const r of realms) void runTest(r.id)
+        for (const r of realms) {
+            void runTest(r.id)
+            void loadBindings(r.id)
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [realms.map((r) => r.id).join(','), runTest])
+    }, [realms.map((r) => r.id).join(','), runTest, loadBindings])
 
     const add = useCallback(async () => {
         if (!form || busy) return
@@ -329,10 +391,16 @@ function RealmsForm({ realms, onChanged }: { realms: Realm[]; onChanged: () => v
     }, [pending, busy, onChanged, toast])
 
     const rows = useMemo<RealmRow[]>(
-        () => realms.map((r) => ({ realm: r, test: tests[r.id] })),
-        [realms, tests],
+        () =>
+            realms.map((r) => ({
+                realm: r,
+                test: tests[r.id],
+                logDest: bindings[r.id]?.find((b) => b.enabled)?.destinationName ?? bindings[r.id]?.[0]?.destinationName,
+            })),
+        [realms, tests, bindings],
     )
     const rotatingRealm = rotating ? realms.find((r) => r.id === rotating) : undefined
+    const logDestRealmObj = logDestRealm ? realms.find((r) => r.id === logDestRealm) : undefined
 
     // Row-action buttons live in the injected tbody HTML — one delegated host
     // listener routes their data-action clicks back to the React handlers.
@@ -348,6 +416,7 @@ function RealmsForm({ realms, onChanged }: { realms: Realm[]; onChanged: () => v
             if (action === 'test') void runTest(id)
             else if (action === 'default') void setDefault(realm)
             else if (action === 'rotate') setRotating(id)
+            else if (action === 'logdest') setLogDestRealm(id)
             else if (action === 'remove') setPending(realm)
         },
         [realms, runTest, setDefault],
@@ -429,6 +498,16 @@ function RealmsForm({ realms, onChanged }: { realms: Realm[]; onChanged: () => v
                 </FormModal>
             )}
 
+            {/* The per-realm log-destination binding editor (logs_feature.md §11). */}
+            {logDestRealmObj && (
+                <RealmLogDestModal
+                    key={logDestRealmObj.id}
+                    realm={logDestRealmObj}
+                    onSaved={() => void loadBindings(logDestRealmObj.id)}
+                    onClose={() => setLogDestRealm(null)}
+                />
+            )}
+
             {/* The write-only token-rotate editor is its own small modal (keyed per realm),
                 so no React subtree is captured by tc-table. */}
             {rotatingRealm && (
@@ -462,6 +541,183 @@ function RealmsForm({ realms, onChanged }: { realms: Realm[]; onChanged: () => v
                 onCancel={() => setPending(null)}
             />
         </>
+    )
+}
+
+/** The realm log-binding editor (logs_feature.md §11): pick an owner-defined
+ *  destination (empty = unbound), shape the stream (labels when the destination is
+ *  loki, filter, shipping tunables — no parse: edge access logs are already JSON),
+ *  toggle enabled, and watch that daemon's live per-destination shipping stats.
+ *  Save → PUT the binding (the fragment is pushed to THIS realm's nginxpilot);
+ *  selecting the empty option and saving → DELETE (fragment retracted). */
+function RealmLogDestModal({
+    realm,
+    onSaved,
+    onClose,
+}: {
+    realm: Realm
+    onSaved: () => void
+    onClose: () => void
+}) {
+    const toast = useToast()
+    const [loaded, setLoaded] = useState(false)
+    const [dests, setDests] = useState<DestOption[]>([])
+    const [existing, setExisting] = useState<LogBindingDto | null>(null)
+    const [destinationId, setDestinationId] = useState('')
+    const [enabled, setEnabled] = useState(true)
+    const [shaping, setShaping] = useState<ShapingDraft>(() => emptyShapingDraft('realm'))
+    const [stats, setStats] = useState<Record<string, LogDestLiveStat>>({})
+    const [error, setError] = useState<string | null>(null)
+    const [busy, setBusy] = useState(false)
+
+    // Load the destination options + this realm's existing binding once.
+    useEffect(() => {
+        let cancelled = false
+        void (async () => {
+            try {
+                const [destList, bindingList] = await Promise.all([
+                    fetch('/api/admin/log-destinations', { cache: 'no-store' }).then((r) => json<DestOption[]>(r)),
+                    fetch(`/api/admin/realms/${encodeURIComponent(realm.id)}/log-bindings`, { cache: 'no-store' }).then(
+                        (r) => json<LogBindingDto[]>(r),
+                    ),
+                ])
+                if (cancelled) return
+                setDests(destList)
+                const binding = bindingList[0] ?? null
+                setExisting(binding)
+                if (binding) {
+                    setDestinationId(binding.destinationId)
+                    setEnabled(binding.enabled)
+                    setShaping(shapingDraftOf(binding.shaping))
+                }
+                setLoaded(true)
+            } catch {
+                if (!cancelled) setError('Couldn’t load the destinations — close and retry.')
+            }
+        })()
+        return () => {
+            cancelled = true
+        }
+    }, [realm.id])
+
+    // Live per-destination shipping stats for THIS realm's daemon (D4).
+    useEffect(() => {
+        let cancelled = false
+        const load = async () => {
+            try {
+                const res = await fetch(
+                    `/api/admin/log-destinations/status?realm=${encodeURIComponent(realm.id)}`,
+                    { cache: 'no-store' },
+                )
+                if (!res.ok || cancelled) return
+                const body = (await res.json()) as { destinations?: LogDestLiveStat[] }
+                const byName: Record<string, LogDestLiveStat> = {}
+                for (const s of body.destinations ?? []) byName[s.name] = s
+                if (!cancelled) setStats(byName)
+            } catch {
+                // best-effort — the modal renders without live stats
+            }
+        }
+        void load()
+        const t = setInterval(() => void load(), 5000)
+        return () => {
+            cancelled = true
+            clearInterval(t)
+        }
+    }, [realm.id])
+
+    const patchShaping = (p: Partial<ShapingDraft>) => setShaping((prev) => ({ ...prev, ...p }))
+
+    const chosen = dests.find((d) => d.id === destinationId)
+    const stat = chosen ? stats[chosen.name] : undefined
+
+    const submit = async () => {
+        if (busy || !loaded) return
+        setBusy(true)
+        setError(null)
+        try {
+            if (!destinationId) {
+                // Empty select = unbound: clear the binding (retracts the fragment).
+                if (existing) {
+                    const res = await fetch(`/api/admin/realms/${encodeURIComponent(realm.id)}/log-bindings`, {
+                        method: 'DELETE',
+                    })
+                    if (!res.ok && res.status !== 204) {
+                        setError(`Couldn’t clear the log destination (error ${res.status}).`)
+                        return
+                    }
+                    toast.show(`Log destination cleared for “${realm.name}”.`, { variant: 'success' })
+                }
+                onSaved()
+                onClose()
+                return
+            }
+            const res = await fetch(`/api/admin/realms/${encodeURIComponent(realm.id)}/log-bindings`, {
+                method: 'PUT',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                    destinationId,
+                    enabled,
+                    shaping: buildShapingPayload(shaping, { scope: 'realm', loki: chosen?.type === 'loki' }),
+                }),
+            })
+            if (!res.ok) {
+                const body = (await res.json().catch(() => null)) as { error?: string; detail?: string } | null
+                setError(
+                    body?.detail
+                        ? `Couldn’t save: ${body.detail}`
+                        : body?.error
+                          ? `Couldn’t save the binding: ${body.error}.`
+                          : `Couldn’t save the binding (error ${res.status}).`,
+                )
+                return
+            }
+            toast.show(`“${realm.name}” now ships its access logs to “${chosen?.name}”.`, { variant: 'success' })
+            onSaved()
+            onClose()
+        } catch {
+            setError('Couldn’t save the binding — network error.')
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    return (
+        <FormModal
+            title={`Log destination — ${realm.name}`}
+            busy={busy}
+            submitLabel="Save"
+            onSubmit={() => void submit()}
+            onClose={onClose}
+        >
+            {error && <tc-banner variant="danger">{error}</tc-banner>}
+            <FormGroup title="Destination">
+                <SelectField
+                    label="Destination"
+                    help="An owner-defined endpoint from the Log destinations page. Empty = this server ships nothing."
+                    value={destinationId}
+                    options={[
+                        { value: '', label: 'None (unbound)' },
+                        ...dests.map((d) => ({ value: d.id, label: `${d.name} — ${d.spec.url}` })),
+                    ]}
+                    onValue={setDestinationId}
+                />
+                {destinationId !== '' && (
+                    <SwitchField label="Enabled" checked={enabled} onChecked={setEnabled} />
+                )}
+                {stat && (
+                    <p className="quaykeeper-admin-hint">
+                        Shipping: ↑ {stat.shipped.toLocaleString()} · ✕ {stat.dropped.toLocaleString()} · ⚠{' '}
+                        {stat.failed_batches.toLocaleString()}
+                        {stat.buffer_len ? ` · buf ${stat.buffer_len}` : ''}
+                        {stat.last_error ? ` — ${stat.last_error}` : ''}
+                    </p>
+                )}
+            </FormGroup>
+            {destinationId !== '' && (
+                <ShapingFields draft={shaping} onPatch={patchShaping} scope="realm" loki={chosen?.type === 'loki'} />
+            )}
+        </FormModal>
     )
 }
 

--- a/quaykeeper/components/config/InstanceDetail.tsx
+++ b/quaykeeper/components/config/InstanceDetail.tsx
@@ -8,13 +8,14 @@ import { ApiError, apiFetch, describeApiError } from '@/lib/fetcher'
 import type { Instance } from '@/server/domain/types'
 import { InstanceVars } from './InstanceVars'
 import { InstanceFlags } from './InstanceFlags'
+import { InstanceLogs } from './InstanceLogs'
 import { InstanceSettings } from './InstanceSettings'
 
-// Per-instance page (`/instances/{id}/{variables|flags|settings}`,
+// Per-instance page (`/instances/{id}/{variables|flags|logs|settings}`,
 // move_wharf_to_perch.md §10). Header via tc-rich-page-header; a route-based
-// SubTabBar (wharf-style sub-nav) switches between the three tabs.
+// SubTabBar (wharf-style sub-nav) switches between the tabs.
 
-export type InstanceTab = 'variables' | 'flags' | 'settings'
+export type InstanceTab = 'variables' | 'flags' | 'logs' | 'settings'
 
 type LoadState =
     | { phase: 'loading' }
@@ -88,6 +89,7 @@ export function InstanceDetail({ instanceId, tab }: { instanceId: string; tab: I
     const tabs: SubTab[] = [
         { id: 'variables', label: 'Variables', icon: 'variable', href: `/instances/${instanceId}/variables` },
         { id: 'flags', label: 'Flags', icon: 'flag', href: `/instances/${instanceId}/flags` },
+        { id: 'logs', label: 'Logs', icon: 'scroll-text', href: `/instances/${instanceId}/logs` },
         { id: 'settings', label: 'Settings', icon: 'settings', href: `/instances/${instanceId}/settings` },
     ]
 
@@ -104,6 +106,7 @@ export function InstanceDetail({ instanceId, tab }: { instanceId: string; tab: I
             <div className="quaykeeper-instance-body">
                 {tab === 'variables' && <InstanceVars instance={instance} />}
                 {tab === 'flags' && <InstanceFlags instanceId={instance.id} />}
+                {tab === 'logs' && <InstanceLogs instanceId={instance.id} />}
                 {tab === 'settings' && (
                     <InstanceSettings
                         instance={instance}

--- a/quaykeeper/components/config/InstanceLogs.tsx
+++ b/quaykeeper/components/config/InstanceLogs.tsx
@@ -1,0 +1,343 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { AdvancedTableColumn } from '@toolcase/web-components'
+import { escapeHtml, useTc } from '@/lib/tc'
+import type { LogShaping } from '@/server/domain/nginxpilot-logdest-fragment'
+import { iconBtnHtml } from '@/lib/action-icons'
+import { callApi, json } from './shared'
+import { ConfirmDialog } from '@/components/ConfirmDialog'
+import { FormModal, FormGroup } from '@/components/FormModal'
+import { SelectField, SwitchField } from '@/components/fields'
+import {
+    ShapingFields,
+    buildShapingPayload,
+    emptyShapingDraft,
+    shapingDraftOf,
+    type ShapingDraft,
+} from '@/components/LogShapingFields'
+import { LoadingState, ErrorState } from '@/components/states'
+import { useToast } from '@/components/Toast'
+
+// Instance Logs tab (logs_feature.md §12): bind owner-defined log destinations to
+// this instance's app logs. Maintainers *choose* from the owner's endpoints (D3)
+// and set the per-binding shaping (labels when the destination is loki, filter,
+// parse templates, shipping tunables). App-log shipping happens client-side via
+// quaykeeper-client; a change here is delivered on the client's next config fetch
+// (the snapshot version bump) — no daemon is involved.
+
+/** One binding as `/api/instances/{id}/logs` returns it. */
+interface LogBindingDto {
+    id: string
+    destinationId: string
+    destinationName: string
+    destinationType: string
+    destinationUrl: string
+    enabled: boolean
+    shaping: LogShaping
+    logql: string
+    updatedAt: string
+}
+
+/** A destination option for the binding select. */
+interface DestOption {
+    id: string
+    name: string
+    type: string
+    url: string
+}
+
+interface LogsData {
+    bindings: LogBindingDto[]
+    destinations: DestOption[]
+}
+
+type LoadState = { phase: 'loading' } | { phase: 'error' } | { phase: 'ready'; data: LogsData }
+
+const LOG_COLUMNS: AdvancedTableColumn[] = [
+    { key: 'destination', label: 'Destination' },
+    { key: 'enabled', label: 'Enabled', width: '8rem' },
+    { key: 'actions', label: '', align: 'right' },
+]
+
+/** The injected <tbody> HTML — every interpolated value is escaped. The enabled
+ *  cell is a real <tc-switch>; its bubbling `change` and the edit/delete buttons'
+ *  clicks are caught by ONE delegated listener via `data-action` (the flags pattern). */
+function bindingRowsHtml(bindings: LogBindingDto[]): string {
+    return bindings
+        .map((b) => {
+            const id = escapeHtml(b.id)
+            const name = escapeHtml(b.destinationName)
+            const toggle =
+                `<tc-switch label="${name}" data-action="toggle" data-id="${id}" data-name="${name}"` +
+                (b.enabled ? ' checked' : '') +
+                `></tc-switch>`
+            const sub = b.destinationType === 'loki' && b.logql ? b.logql : b.destinationUrl
+            const controls = [
+                iconBtnHtml({ icon: 'edit', label: `Edit binding for ${b.destinationName}`, data: { action: 'edit', id: b.id } }),
+                iconBtnHtml({
+                    icon: 'remove',
+                    label: `Remove binding for ${b.destinationName}`,
+                    danger: true,
+                    data: { action: 'delete', id: b.id, name: b.destinationName },
+                }),
+            ].join('')
+            return (
+                `<tr>` +
+                `<td><span class="quaykeeper-admin-realm-id">` +
+                `<span class="quaykeeper-admin-realm-name">${name}</span>` +
+                `<span class="quaykeeper-admin-mono quaykeeper-admin-hint">${escapeHtml(sub)}</span>` +
+                `<span class="quaykeeper-admin-badges"><span class="badge text-bg-info">${escapeHtml(b.destinationType)}</span></span>` +
+                `</span></td>` +
+                `<td>${toggle}</td>` +
+                `<td style="text-align:right"><span class="quaykeeper-admin-domain-controls">${controls}</span></td>` +
+                `</tr>`
+            )
+        })
+        .join('')
+}
+
+interface BindingDraft {
+    /** null = creating; the binding id when editing (destination immutable then). */
+    bindingId: string | null
+    destinationId: string
+    enabled: boolean
+    shaping: ShapingDraft
+}
+
+export function InstanceLogs({ instanceId }: { instanceId: string }) {
+    const toast = useToast()
+    const [state, setState] = useState<LoadState>({ phase: 'loading' })
+    const [form, setForm] = useState<BindingDraft | null>(null)
+    const [pending, setPending] = useState<{ id: string; name: string } | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [busy, setBusy] = useState(false)
+
+    const data = useMemo<LogsData>(
+        () => (state.phase === 'ready' ? state.data : { bindings: [], destinations: [] }),
+        [state],
+    )
+
+    const load = useCallback(async () => {
+        setState({ phase: 'loading' })
+        try {
+            const next = await fetch(`/api/instances/${instanceId}/logs`, { cache: 'no-store' }).then((r) =>
+                json<LogsData>(r),
+            )
+            setState({ phase: 'ready', data: next })
+        } catch {
+            setState({ phase: 'error' })
+        }
+    }, [instanceId])
+
+    useEffect(() => {
+        void load()
+    }, [load])
+
+    const toggle = useCallback(
+        async (id: string, name: string, enabled: boolean) => {
+            const res = await callApi(`/api/instances/${instanceId}/logs/${id}`, 'PATCH', { enabled })
+            if (!res.ok) {
+                toast.show(`Couldn’t update “${name}”: ${res.message}`, { variant: 'error' })
+            }
+            // Reload either way: sync updatedAt on success, revert the switch on failure.
+            void load()
+        },
+        [instanceId, load, toast],
+    )
+
+    // One delegated handler for everything inside the injected rows.
+    const onDelegated = useCallback(
+        (event: Event) => {
+            const el = (event.target as HTMLElement)?.closest?.('[data-action]') as HTMLElement | null
+            if (!el) return
+            const action = el.getAttribute('data-action')
+            const id = el.getAttribute('data-id')
+            const name = el.getAttribute('data-name') ?? ''
+            if (!action || !id) return
+            if (action === 'toggle' && event.type === 'change') {
+                const checked = (el as HTMLElement & { checked?: boolean }).checked === true
+                void toggle(id, name, checked)
+            } else if (action === 'edit' && event.type === 'click') {
+                const binding = data.bindings.find((b) => b.id === id)
+                if (!binding) return
+                setError(null)
+                setForm({
+                    bindingId: binding.id,
+                    destinationId: binding.destinationId,
+                    enabled: binding.enabled,
+                    shaping: shapingDraftOf(binding.shaping),
+                })
+            } else if (action === 'delete' && event.type === 'click') {
+                setPending({ id, name })
+            }
+        },
+        [toggle, data.bindings],
+    )
+
+    const tableProps = useMemo(
+        () => ({
+            columns: LOG_COLUMNS,
+            total: data.bindings.length,
+            limit: Math.max(data.bindings.length, 1),
+            offset: 0,
+            rows: bindingRowsHtml(data.bindings),
+        }),
+        [data.bindings],
+    )
+    const tableRef = useTc<HTMLElement>(tableProps, { click: onDelegated, change: onDelegated })
+
+    const openCreate = () => {
+        setError(null)
+        setForm({
+            bindingId: null,
+            destinationId: data.destinations[0]?.id ?? '',
+            enabled: true,
+            shaping: emptyShapingDraft('instance'),
+        })
+    }
+    const closeForm = () => {
+        setForm(null)
+        setError(null)
+    }
+
+    const chosenDest = form ? data.destinations.find((d) => d.id === form.destinationId) : undefined
+
+    const submit = useCallback(async () => {
+        if (!form || busy) return
+        if (!form.destinationId) {
+            setError('Pick a destination.')
+            return
+        }
+        setBusy(true)
+        setError(null)
+        const dest = data.destinations.find((d) => d.id === form.destinationId)
+        const shaping = buildShapingPayload(form.shaping, { scope: 'instance', loki: dest?.type === 'loki' })
+        const res = form.bindingId
+            ? await callApi(`/api/instances/${instanceId}/logs/${form.bindingId}`, 'PATCH', {
+                  enabled: form.enabled,
+                  shaping,
+              })
+            : await callApi(`/api/instances/${instanceId}/logs`, 'POST', {
+                  destinationId: form.destinationId,
+                  enabled: form.enabled,
+                  shaping,
+              })
+        setBusy(false)
+        if (!res.ok) {
+            setError(`Couldn’t save the log destination: ${res.message}`)
+            return
+        }
+        toast.show(
+            form.bindingId ? `Log binding for “${dest?.name}” updated.` : `Logs now ship to “${dest?.name}”.`,
+            { variant: 'success' },
+        )
+        setForm(null)
+        void load()
+    }, [form, busy, instanceId, data.destinations, load, toast])
+
+    const doDelete = useCallback(async () => {
+        if (!pending || busy) return
+        const { id, name } = pending
+        setPending(null)
+        setBusy(true)
+        const res = await callApi(`/api/instances/${instanceId}/logs/${id}`, 'DELETE')
+        setBusy(false)
+        if (!res.ok) {
+            toast.show(`Couldn’t remove “${name}”: ${res.message}`, { variant: 'error' })
+            return
+        }
+        toast.show(`Log binding for “${name}” removed.`, { variant: 'success' })
+        void load()
+    }, [pending, busy, instanceId, load, toast])
+
+    if (state.phase === 'loading') return <LoadingState shape="rows" count={3} />
+    if (state.phase === 'error') {
+        return (
+            <ErrorState
+                title="Couldn’t load log destinations"
+                message="The log bindings didn’t come back. This is usually temporary."
+                onRetry={() => void load()}
+            />
+        )
+    }
+
+    const { bindings, destinations } = data
+
+    return (
+        <>
+            <tc-section-card title="Log shipping" icon="scroll-text">
+                <div className="quaykeeper-admin-section">
+                    <p className="quaykeeper-home-lead quaykeeper-admin-hint">
+                        Ship this instance’s app logs to an owner-defined destination. Shipping happens client-side via
+                        quaykeeper-client; changes are delivered on the next config fetch. Credentials are referenced by
+                        env-var / file name — provision them as instance variables.
+                    </p>
+                    {error && !form && <tc-banner variant="danger">{error}</tc-banner>}
+                    <div className="quaykeeper-instance-toolbar">
+                        <tc-button variant="primary" size="sm" onClick={openCreate} disabled={destinations.length === 0}>
+                            Add log destination
+                        </tc-button>
+                    </div>
+                    {bindings.length === 0 ? (
+                        <tc-empty-state icon="scroll-text">
+                            {destinations.length === 0
+                                ? 'No destinations exist yet — an owner defines them under Admin → Log destinations.'
+                                : 'No log destinations bound yet.'}
+                        </tc-empty-state>
+                    ) : (
+                        <tc-advanced-table ref={tableRef} />
+                    )}
+                </div>
+            </tc-section-card>
+
+            {form && (
+                <FormModal
+                    key={form.bindingId ?? 'new'}
+                    title={form.bindingId ? `Edit — ${chosenDest?.name ?? ''}` : 'Add log destination'}
+                    busy={busy}
+                    submitLabel={form.bindingId ? 'Save' : 'Bind destination'}
+                    onSubmit={() => void submit()}
+                    onClose={closeForm}
+                >
+                    {error && <tc-banner variant="danger">{error}</tc-banner>}
+                    <FormGroup title="Destination">
+                        <SelectField
+                            label="Destination"
+                            help="Owner-defined endpoint (Admin → Log destinations). Immutable per binding — remove and re-add to switch."
+                            value={form.destinationId}
+                            disabled={form.bindingId !== null}
+                            options={destinations.map((d) => ({ value: d.id, label: `${d.name} — ${d.url}` }))}
+                            onValue={(v) => setForm((p) => (p ? { ...p, destinationId: v } : p))}
+                        />
+                        <SwitchField
+                            label="Enabled"
+                            checked={form.enabled}
+                            onChecked={(c) => setForm((p) => (p ? { ...p, enabled: c } : p))}
+                        />
+                    </FormGroup>
+                    <ShapingFields
+                        draft={form.shaping}
+                        onPatch={(p) => setForm((prev) => (prev ? { ...prev, shaping: { ...prev.shaping, ...p } } : prev))}
+                        scope="instance"
+                        loki={chosenDest?.type === 'loki'}
+                    />
+                </FormModal>
+            )}
+
+            <ConfirmDialog
+                open={!!pending}
+                title="Remove log binding?"
+                message={
+                    pending
+                        ? `Stop shipping this instance’s logs to “${pending.name}”. Applied on the client’s next config fetch.`
+                        : undefined
+                }
+                confirmLabel="Remove"
+                danger
+                onConfirm={() => void doDelete()}
+                onCancel={() => setPending(null)}
+            />
+        </>
+    )
+}

--- a/quaykeeper/components/config/InstanceSettings.tsx
+++ b/quaykeeper/components/config/InstanceSettings.tsx
@@ -140,6 +140,18 @@ export function InstanceSettings({
         `CMD ["./my-app", "--serve"]`,
     ].join('\n')
 
+    const dockerRunSnippet = [
+        `# docker run — same bootstrap against a stock image, no Dockerfile: override`,
+        `# the entrypoint to fetch install.sh, which downloads the client and execs your app`,
+        `docker run -d \\`,
+        `    -e QUAYKEEPER_URL=${agentUrl} \\`,
+        `    -e QUAYKEEPER_INSTANCE=${instance.name} \\`,
+        `    -e QUAYKEEPER_SECRET="$QUAYKEEPER_SECRET" \\`,
+        `    --entrypoint /bin/sh \\`,
+        `    my-app:latest \\`,
+        `    -c 'wget -qO- "$QUAYKEEPER_URL/v1/install.sh" | sh -s -- exec -- ./my-app --serve'`,
+    ].join('\n')
+
     const modesSnippet = [
         `quaykeeper-client exec -- ./app --serve        # fetch once, inject as env, exec (PID-1 handoff)`,
         `quaykeeper-client write --format dotenv --out /app/.env    # materialize to a file`,
@@ -235,6 +247,12 @@ export function InstanceSettings({
                             config injected as env — fails closed if the fetch fails):
                         </p>
                         <tc-code-snippet code={entrypointSnippet} language="bash" title="Dockerfile" show-copy-button="" />
+                        <p className="quaykeeper-admin-hint">
+                            Or run a stock image the same way without a custom Dockerfile — override the entrypoint at{' '}
+                            <code>docker run</code> time (export the fetch secret in your shell first so it is never baked
+                            into the image or the command text):
+                        </p>
+                        <tc-code-snippet code={dockerRunSnippet} language="bash" title="docker run" show-copy-button="" />
                         <p className="quaykeeper-admin-hint">Or run one of the three modes directly:</p>
                         <tc-code-snippet code={modesSnippet} language="bash" title="Modes" show-copy-button="" />
                         <p className="quaykeeper-admin-hint">Or embed it as a library in your Go service:</p>

--- a/quaykeeper/components/config/Instances.tsx
+++ b/quaykeeper/components/config/Instances.tsx
@@ -96,7 +96,7 @@ export function Instances() {
 
     return (
         <ConfigPage
-            title="Variables"
+            title="Instances"
             subtitle="Flat list of instances carrying variables and flags, organized by project and tags. Maintainer access."
             icon="server"
             iconColor="cyan"

--- a/quaykeeper/components/snippets/SnippetEditor.tsx
+++ b/quaykeeper/components/snippets/SnippetEditor.tsx
@@ -428,7 +428,7 @@ export function SnippetEditor({
                     checked={!!spec.inject}
                     onChecked={setInject}
                     label="Inject instance variables at boot"
-                    help="Rewrites the entrypoint inline: the container fetches the instance's resolved variables from the agent server, exports them, then execs your command."
+                    help="Rewrites the entrypoint inline: the container fetches install.sh, downloads the quaykeeper-client binary, pulls the instance's resolved variables, then execs your command."
                 />
                 {spec.inject && (
                     <>
@@ -442,7 +442,7 @@ export function SnippetEditor({
                             />
                             <SelectField
                                 label="Fetch tool"
-                                help="Whichever the image ships."
+                                help="Which tool fetches install.sh — whichever the image ships (it then auto-detects the binary download tool)."
                                 value={spec.inject.tool}
                                 options={TOOL_OPTIONS}
                                 onValue={(v) => patchSpec({ inject: { tool: v as InjectTool } })}

--- a/quaykeeper/components/snippets/Snippets.tsx
+++ b/quaykeeper/components/snippets/Snippets.tsx
@@ -178,7 +178,7 @@ function SnippetsTable({ data, onChanged }: { data: SnippetsData; onChanged: () 
                     <p className="quaykeeper-home-lead quaykeeper-admin-hint">
                         {data.snippets.length} snippet{data.snippets.length === 1 ? '' : 's'}. Each is a reusable{' '}
                         <code>docker run</code> command — click a name to copy it. Attaching a variables instance
-                        rewrites the entrypoint inline so the container pulls its config at boot.
+                        rewrites the entrypoint so the container fetches its config via the quaykeeper-client at boot.
                     </p>
 
                     <div className="quaykeeper-instance-toolbar">
@@ -274,9 +274,10 @@ function CommandModal({
                 <tc-code-snippet code={cmd} language="bash" title="docker run" show-copy-button="" />
                 {injecting && (
                     <p className="quaykeeper-admin-hint">
-                        At boot the container fetches the instance’s resolved variables from the agent server (
-                        <code>{agentUrl}/v1/env?format=shell</code>), exports them, then execs your command. If the fetch
-                        fails the container exits instead of starting half-configured.
+                        At boot the container fetches the bootstrap (<code>{agentUrl}/v1/install.sh</code>), which
+                        downloads the matching <code>quaykeeper-client</code> binary, pulls the instance’s resolved
+                        variables, and execs your command. If the fetch fails the container exits instead of starting
+                        half-configured.
                     </p>
                 )}
             </div>

--- a/quaykeeper/lib/action-icons.tsx
+++ b/quaykeeper/lib/action-icons.tsx
@@ -27,6 +27,7 @@ import {
     Play,
     Power,
     RefreshCw,
+    ScrollText,
     Server,
     SlidersHorizontal,
     Star,
@@ -58,6 +59,7 @@ export const ACTION_ICONS = {
     rotate: stripSize(KeyRound),
     suspend: stripSize(Ban),
     limits: stripSize(SlidersHorizontal),
+    logs: stripSize(ScrollText),
     realms: stripSize(Server),
     close: stripSize(X),
 } as const

--- a/quaykeeper/server/data/db.ts
+++ b/quaykeeper/server/data/db.ts
@@ -75,11 +75,24 @@ function wrap(): DbWrap {
 
 // ── migrations ─────────────────────────────────────────────────────────────
 // Ordered, append-only list of schema SQL. Each entry's index+1 is its version;
-// never reorder or rewrite an applied migration — add a new one.
+// never reorder or rewrite an applied migration — add a new one. An entry may
+// also be a function (DDL + row-level backfill in TS) — it runs inside the same
+// per-version transaction as a SQL entry.
 
-const MIGRATIONS: string[] = [
-    // v1 — initial schema (notes/static-hosting-app-design.md §12)
+type Migration = string | ((db: DatabaseSync) => void)
+
+const MIGRATIONS: Migration[] = [
+    // v1 — the complete Quaykeeper schema. Formerly 21 incremental migrations
+    // (initial schema → realms → the Config subsystem → db servers → snippets →
+    // scheduled jobs → log destinations → the log endpoint/binding split),
+    // squashed into this single entry once the split landed. Squashing implies
+    // fresh-database semantics: a database that already ran the old sequence has
+    // version 1 recorded and skips this entry (its schema is equivalent, apart
+    // from log_destination's deprecated scope/target/enabled columns which this
+    // merged DDL drops outright and no code reads); a database stranded mid-way
+    // through the old sequence has no upgrade path and must be recreated.
     `
+    -- Users + roles (static-hosting-app-design.md §12).
     CREATE TABLE app_user (
         github_id  INTEGER PRIMARY KEY,
         login      TEXT NOT NULL,
@@ -89,65 +102,8 @@ const MIGRATIONS: string[] = [
         added_at   TEXT NOT NULL
     );
 
-    CREATE TABLE base_domain (               -- owner-managed subdomain pool
-        domain     TEXT PRIMARY KEY,         -- e.g. quaykeeper.dev
-        created_at TEXT NOT NULL
-    );
-
-    CREATE TABLE site (
-        id          TEXT PRIMARY KEY,        -- short id; also the fragment filename suffix
-        owner_id    INTEGER NOT NULL,        -- app_user.github_id
-        repo_owner  TEXT NOT NULL,
-        repo_name   TEXT NOT NULL,
-        branch      TEXT NOT NULL,
-        subdir      TEXT,
-        hostname    TEXT NOT NULL UNIQUE,    -- alice.quaykeeper.dev | www.example.com
-        host_kind   TEXT NOT NULL,           -- subdomain | custom
-        status      TEXT NOT NULL,           -- draft|provisioning|live|failed|suspended|over_quota
-        bytes       INTEGER,                 -- last measured deployed size
-        last_ref    TEXT,                    -- last live git ref (from /status)
-        last_error  TEXT,
-        created_at  TEXT NOT NULL,
-        updated_at  TEXT NOT NULL
-    );
-    CREATE INDEX idx_site_owner ON site(owner_id);
-
-    CREATE TABLE sponsorship (
-        sponsor_login TEXT PRIMARY KEY,      -- == app_user.login
-        tier_cents    INTEGER NOT NULL,
-        status        TEXT NOT NULL,         -- active | pending_cancel | cancelled
-        effective_at  TEXT NOT NULL,
-        updated_at    TEXT NOT NULL
-    );
-
-    CREATE TABLE plan_tier (                 -- owner-editable $ → plan mapping
-        min_cents INTEGER PRIMARY KEY,
-        plan      TEXT NOT NULL              -- bronze | silver | gold
-    );
-
-    CREATE TABLE audit (                     -- mirror TaskForge audit log
-        id        INTEGER PRIMARY KEY AUTOINCREMENT,
-        at        TEXT NOT NULL,
-        github_id INTEGER,
-        login     TEXT,
-        action    TEXT NOT NULL,
-        site      TEXT,
-        detail    TEXT
-    );
-    CREATE INDEX idx_audit_id ON audit(id DESC);
-    `,
-    // v2 — base-domain audience tiers (§10). Each base domain is offered to one of
-    // three groups: free accounts, paid (sponsored) accounts, or staff (maintainer/
-    // owner). Existing rows default to `free` so nothing a user could already pick
-    // disappears on upgrade.
-    `
-    ALTER TABLE base_domain ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';  -- free | paid | staff
-    `,
-    // v3 — per-user custom limit overrides (§11, §15). An owner can tweak any one
-    // user's quotas above/below their role/plan default. A row exists only when a
-    // user is customised; every column is nullable and a NULL field inherits the
-    // default. Cascades away if the user row is ever deleted.
-    `
+    -- Per-user quota overrides (§11, §15). A row exists only when a user is
+    -- customised; every column is nullable and a NULL field inherits the default.
     CREATE TABLE user_limit (
         github_id          INTEGER PRIMARY KEY REFERENCES app_user(github_id) ON DELETE CASCADE,
         max_sites          INTEGER,        -- NULL = inherit role/plan default
@@ -159,47 +115,32 @@ const MIGRATIONS: string[] = [
         private_repos      INTEGER,        -- 0 | 1 | NULL (inherit)
         updated_at         TEXT NOT NULL
     );
-    `,
-    // v4 — global instance settings (owner-editable branding + custom-domain
-    // ingress). A generic key/value store: one row per setting, value is the raw
-    // string the UI persisted (validated in `domain/settings.ts` before it lands).
-    // A missing key falls through to its built-in default / env fallback, so the
-    // table is empty on a fresh instance and every setting is optional.
-    `
-    CREATE TABLE app_setting (
-        key        TEXT PRIMARY KEY,       -- app_name | tagline | theme | brand_color | ingress_ipv4 | ingress_ipv6
-        value      TEXT NOT NULL,
+
+    -- Durable GitHub credential (private-repo support): the user's OAuth access
+    -- token, AES-256-GCM-encrypted via infrastructure/cipher.ts — never plaintext
+    -- at rest, never sent to the client.
+    CREATE TABLE user_github_token (
+        github_id  INTEGER PRIMARY KEY REFERENCES app_user(github_id) ON DELETE CASCADE,
+        token_enc  TEXT NOT NULL,
         updated_at TEXT NOT NULL
     );
-    `,
-    // v5 — per-base-domain subdomain TLS policy (§0/Phase D). One wildcard cert per base
-    // domain covers every `<label>.<base>` subdomain, so TLS is decided once here, never
-    // per subdomain. `auto` degrades to HTTP when the cert isn't issued yet (so a missing
-    // cert never takes subdomains down); existing rows default to `auto`. Inert unless
-    // nginxpilot runs in managed mode.
-    `
-    ALTER TABLE base_domain ADD COLUMN tls TEXT NOT NULL DEFAULT 'auto';  -- off | auto
-    `,
-    // v6 — realms: registered nginxpilot instances (owner-managed, multiple_realms.md §2.1).
-    // Each realm is one nginxpilot the control plane can drive. `token_enc` is the
-    // AES-256-GCM ciphertext of the bearer token (NULL = unauthenticated instance); the
-    // plaintext token never leaves the server. The partial unique index enforces "exactly
-    // one default realm" at the DB layer — setting a new default is a two-step tx.
-    `
+
+    -- Realms: registered nginxpilot instances (multiple_realms.md §2.1). token_enc
+    -- is the AES-256-GCM ciphertext of the bearer token (NULL = unauthenticated);
+    -- the plaintext never leaves the server. The partial unique index enforces
+    -- "exactly one default realm" at the DB layer.
     CREATE TABLE realm (
         id          TEXT PRIMARY KEY,         -- server-generated short id
         name        TEXT NOT NULL,            -- human label ("prod-eu", "lab")
         admin_url   TEXT NOT NULL,            -- https://nginxpilot.internal:9090 (normalized, no trailing /)
-        token_enc   TEXT,                     -- AES-256-GCM ciphertext of the bearer token; NULL = unauthenticated
+        token_enc   TEXT,                     -- AES-256-GCM ciphertext; NULL = unauthenticated
         is_default  INTEGER NOT NULL DEFAULT 0,
         created_at  TEXT NOT NULL
     );
     CREATE UNIQUE INDEX idx_realm_one_default ON realm(is_default) WHERE is_default = 1;
-    `,
-    // v7 — per-user realm access grants (M:N, multiple_realms.md §2.1). A row = "this user
-    // may use this realm". `is_default` marks the user's own operating realm among their
-    // grants (owner-managed; non-owners never switch, §0.6). Cascades with the user/realm.
-    `
+
+    -- Per-user realm access grants (M:N). is_default marks the user's own operating
+    -- realm among their grants (owner-managed; non-owners never switch, §0.6).
     CREATE TABLE user_realm (
         github_id  INTEGER NOT NULL REFERENCES app_user(github_id) ON DELETE CASCADE,
         realm_id   TEXT    NOT NULL REFERENCES realm(id)           ON DELETE CASCADE,
@@ -207,86 +148,73 @@ const MIGRATIONS: string[] = [
         granted_at TEXT    NOT NULL,
         PRIMARY KEY (github_id, realm_id)
     );
-    `,
-    // v8 — sites belong to a realm (the instance they deploy to, multiple_realms.md §2.1,
-    // §10.2). Hostname uniqueness becomes PER-REALM: two nginx ingresses are independent,
-    // so the same hostname can legitimately exist in each. SQLite can't drop a column-level
-    // UNIQUE in place, so rebuild the table: add `realm_id`, swap the global UNIQUE(hostname)
-    // for UNIQUE(realm_id, hostname). `realm_id` is left NULL here and backfilled to the
-    // seed default realm at boot (`services/realms.ts` ensureSeed), after which app code
-    // treats it as required. This is a CREATE-new / DROP-old / RENAME rebuild, which SQLite
-    // requires `foreign_keys` to be OFF for — the migration runner toggles it OFF around the
-    // whole run and back ON afterwards (D2), so a future inbound FK can't silently corrupt
-    // data on an un-migrated instance. (A `PRAGMA` inside this SQL would be a no-op — it runs
-    // inside the migration's `BEGIN`/`COMMIT`, where SQLite ignores the foreign_keys toggle.)
-    `
-    CREATE TABLE site_new (
-        id          TEXT PRIMARY KEY,
-        owner_id    INTEGER NOT NULL,
-        repo_owner  TEXT NOT NULL,
-        repo_name   TEXT NOT NULL,
-        branch      TEXT NOT NULL,
-        subdir      TEXT,
-        hostname    TEXT NOT NULL,
-        host_kind   TEXT NOT NULL,
-        status      TEXT NOT NULL,
-        bytes       INTEGER,
-        last_ref    TEXT,
-        last_error  TEXT,
-        realm_id    TEXT REFERENCES realm(id),
-        created_at  TEXT NOT NULL,
-        updated_at  TEXT NOT NULL
+
+    -- Owner-managed subdomain pool. Each base domain belongs to one realm (a
+    -- wildcard is served by exactly one instance), is offered to one audience
+    -- tier, and carries the per-base wildcard TLS policy (auto degrades to HTTP
+    -- while the cert isn't issued, so a missing cert never takes subdomains down).
+    CREATE TABLE base_domain (
+        domain     TEXT PRIMARY KEY,              -- e.g. quaykeeper.dev
+        tier       TEXT NOT NULL DEFAULT 'free',  -- free | paid | staff
+        tls        TEXT NOT NULL DEFAULT 'auto',  -- off | auto
+        realm_id   TEXT REFERENCES realm(id),     -- NULL only until the boot backfill assigns the default realm
+        created_at TEXT NOT NULL
     );
-    INSERT INTO site_new (id, owner_id, repo_owner, repo_name, branch, subdir, hostname,
-                          host_kind, status, bytes, last_ref, last_error, realm_id, created_at, updated_at)
-        SELECT id, owner_id, repo_owner, repo_name, branch, subdir, hostname,
-               host_kind, status, bytes, last_ref, last_error, NULL, created_at, updated_at
-        FROM site;
-    DROP TABLE site;
-    ALTER TABLE site_new RENAME TO site;
+
+    -- Sites. Hostname uniqueness is PER-REALM (two nginx ingresses are independent,
+    -- so the same hostname can legitimately exist in each). realm_id is assigned by
+    -- the boot backfill (services/realms.ts ensureSeed), after which app code treats
+    -- it as required.
+    CREATE TABLE site (
+        id           TEXT PRIMARY KEY,        -- short id; also the fragment filename suffix
+        owner_id     INTEGER NOT NULL,        -- app_user.github_id
+        repo_owner   TEXT NOT NULL,
+        repo_name    TEXT NOT NULL,
+        branch       TEXT NOT NULL,
+        subdir       TEXT,
+        hostname     TEXT NOT NULL,           -- alice.quaykeeper.dev | www.example.com
+        host_kind    TEXT NOT NULL,           -- subdomain | custom
+        status       TEXT NOT NULL,           -- draft|provisioning|live|failed|suspended|over_quota
+        bytes        INTEGER,                 -- last measured deployed size
+        last_ref     TEXT,                    -- last live git ref (from /status)
+        last_error   TEXT,
+        repo_private INTEGER NOT NULL DEFAULT 0,  -- redeploys re-emit the fragment auth block without a GitHub round-trip
+        realm_id     TEXT REFERENCES realm(id),
+        created_at   TEXT NOT NULL,
+        updated_at   TEXT NOT NULL
+    );
     CREATE INDEX idx_site_owner ON site(owner_id);
     CREATE UNIQUE INDEX idx_site_realm_hostname ON site(realm_id, hostname);
-    `,
-    // v9 — base-domain pools belong to a realm (multiple_realms.md §2.1, §10.4): a
-    // wildcard is served by exactly one instance. Nullable to survive the ALTER; the seed
-    // backfill assigns the default realm at boot, after which app code treats it as set.
-    `
-    ALTER TABLE base_domain ADD COLUMN realm_id TEXT REFERENCES realm(id);
-    `,
-    // v10 — sponsorships are keyed by the sponsor's IMMUTABLE numeric GitHub id, not
-    // their (reusable) login (S3). A recycled username could otherwise inherit a stale
-    // sponsorship and silently get a paid plan. Rebuild the table: `sponsor_id` becomes
-    // the PK (== app_user.github_id), `sponsor_login` is kept for display only. Existing
-    // rows are backfilled by joining the old login-keyed rows to app_user; rows whose
-    // login has no matching user can't be linked to an id (and granted nothing under
-    // id-based resolution, since plan lookup needs the user row), so they're dropped —
-    // the GraphQL reconcile re-creates any still-valid sponsorship with its id within a
-    // minute. CREATE-new / DROP-old / RENAME rebuild (foreign_keys is toggled OFF around
-    // the whole migration run; see `migrate`).
-    `
-    CREATE TABLE sponsorship_new (
-        sponsor_id    INTEGER PRIMARY KEY,     -- == app_user.github_id (immutable)
-        sponsor_login TEXT NOT NULL,           -- display only; NOT the key
-        tier_cents    INTEGER NOT NULL,
-        status        TEXT NOT NULL,           -- active | pending_cancel | cancelled
-        effective_at  TEXT NOT NULL,
-        updated_at    TEXT NOT NULL
+
+    -- Global instance settings (owner-editable branding + custom-domain ingress).
+    -- Generic key/value; empty on a fresh instance — a missing key falls through
+    -- to its built-in default / env fallback (domain/settings.ts validates writes).
+    CREATE TABLE app_setting (
+        key        TEXT PRIMARY KEY,       -- app_name | tagline | theme | brand_color | ingress_ipv4 | ingress_ipv6
+        value      TEXT NOT NULL,
+        updated_at TEXT NOT NULL
     );
-    INSERT INTO sponsorship_new (sponsor_id, sponsor_login, tier_cents, status, effective_at, updated_at)
-        SELECT u.github_id, s.sponsor_login, s.tier_cents, s.status, s.effective_at, s.updated_at
-        FROM sponsorship s
-        JOIN app_user u ON u.login = s.sponsor_login;
-    DROP TABLE sponsorship;
-    ALTER TABLE sponsorship_new RENAME TO sponsorship;
-    `,
-    // v11 — persisted per-resource state history (quaykeeper_better.md B1). One row per
-    // non-active EPISODE of a managed-mode resource (disabled / at_risk / a cert
-    // renew failure): opened when the status poller first sees the state, refreshed
-    // while it persists, closed (cleared_at) on recovery. Unlike the daemon's
-    // in-memory view this survives daemon AND quaykeeper restarts. The actor_* columns
-    // denormalize "who last touched this resource" from the audit log at episode-open
-    // time, so attribution survives audit pruning.
-    `
+
+    -- Audit log. meta is a nullable JSON snapshot of the written object (secrets
+    -- stripped at the call site — cert keys and credential bodies never pass through).
+    CREATE TABLE audit (
+        id        INTEGER PRIMARY KEY AUTOINCREMENT,
+        at        TEXT NOT NULL,
+        github_id INTEGER,
+        login     TEXT,
+        action    TEXT NOT NULL,
+        site      TEXT,
+        detail    TEXT,
+        meta      TEXT
+    );
+    CREATE INDEX idx_audit_id ON audit(id DESC);
+
+    -- Persisted per-resource state history (quaykeeper_better.md B1). One row per
+    -- non-active EPISODE of a managed-mode resource (disabled / at_risk / a cert
+    -- renew failure): opened when the status poller first sees the state, refreshed
+    -- while it persists, closed (cleared_at) on recovery — survives daemon AND
+    -- quaykeeper restarts. The actor_* columns denormalize "who last touched this
+    -- resource" from the audit log at episode-open time, surviving audit pruning.
     CREATE TABLE resource_state (
         id           INTEGER PRIMARY KEY AUTOINCREMENT,
         realm_id     TEXT NOT NULL,
@@ -304,47 +232,13 @@ const MIGRATIONS: string[] = [
     );
     CREATE UNIQUE INDEX idx_resource_state_open ON resource_state(realm_id, kind, key) WHERE cleared_at IS NULL;
     CREATE INDEX idx_resource_state_history ON resource_state(realm_id, kind, key, id DESC);
-    `,
-    // v12 — audit enrichment (quaykeeper_better.md B3): a nullable `meta` JSON column
-    // holding a snapshot of the written object (the parsed entity / request shape,
-    // secrets stripped at the call site — cert keys and credential bodies never pass
-    // through). NULL for entries that predate it or have nothing to snapshot.
-    `
-    ALTER TABLE audit ADD COLUMN meta TEXT;
-    `,
-    // v13 — the multi-plan system is gone (impl §9): every account runs on the single
-    // standard baseline plus its optional per-user `user_limit` override, so the
-    // sponsorship mirror and the $ → plan mapping have no readers. Dropping the tables
-    // (not just the code) keeps the schema honest; the historical audit entries
-    // (`admin.plan_tier.replace`, sponsorship events) remain in the audit log.
-    `
-    DROP TABLE IF EXISTS sponsorship;
-    DROP TABLE IF EXISTS plan_tier;
-    `,
-    // v14 — durable GitHub credential (private-repo support). The user's OAuth access
-    // token, AES-256-GCM-encrypted with the realm cipher keyring (never plaintext at
-    // rest, never sent to the client). Replaces the 10-minute `quaykeeper_gh_token` cookie
-    // as the wizard's repo/branch-listing credential, and is pushed to nginxpilot's
-    // git-credentials store so private sites keep syncing on interval. Plus a
-    // `repo_private` flag on `site` so redeploys know to re-emit the fragment's
-    // `auth` block without a GitHub round-trip.
-    `
-    CREATE TABLE user_github_token (
-        github_id  INTEGER PRIMARY KEY REFERENCES app_user(github_id) ON DELETE CASCADE,
-        token_enc  TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-    );
-    ALTER TABLE site ADD COLUMN repo_private INTEGER NOT NULL DEFAULT 0;
-    `,
-    // v15 — the Config subsystem (move_wharf_to_perch.md §3): wharf's configuration
-    // management, redesigned as a flat, tag-organized model. Two global pools (plain
-    // variables, encrypted secrets) plus a flat list of instances — no
-    // projects/environments, no override cascade, no interpolation. Ships as one
-    // migration (all six tables land together; partial rollout has no value).
-    // Cascade rules: deleting an instance drops its tags/vars/flags; deleting a
-    // referenced global var/secret is blocked (ON DELETE RESTRICT) so a fetch never
-    // silently loses a value.
-    `
+
+    -- The Config subsystem (move_wharf_to_perch.md §3): two global pools (plain
+    -- variables, encrypted secrets) plus a flat, tag/project-organized instance
+    -- list — no projects/environments, no override cascade, no interpolation.
+    -- Cascade rules: deleting an instance drops its tags/vars/flags; deleting a
+    -- referenced global var/secret is blocked (ON DELETE RESTRICT) so a fetch
+    -- never silently loses a value.
     CREATE TABLE global_var (
         id          TEXT PRIMARY KEY,
         key         TEXT NOT NULL UNIQUE,
@@ -368,6 +262,7 @@ const MIGRATIONS: string[] = [
         id             TEXT PRIMARY KEY,
         name           TEXT NOT NULL UNIQUE,
         description    TEXT,
+        project        TEXT,                   -- plain grouping label; NULL = unassigned
         key_hash       TEXT,                   -- sha256 of fetch secret; NULL until minted
         key_set_at     TEXT,
         key_expires_at TEXT,
@@ -375,6 +270,7 @@ const MIGRATIONS: string[] = [
         created_at     TEXT NOT NULL,
         updated_at     TEXT NOT NULL
     );
+    CREATE INDEX idx_instance_project ON instance(project);
 
     CREATE TABLE instance_tag (
         instance_id TEXT NOT NULL REFERENCES instance(id) ON DELETE CASCADE,
@@ -416,14 +312,11 @@ const MIGRATIONS: string[] = [
         UNIQUE(instance_id, key)
     );
     CREATE INDEX idx_feature_flag_instance ON feature_flag(instance_id);
-    `,
-    // v16 — database-server registry (quaykeeper_database_management.md §4). One row per
-    // owner-connected database server. `admin_password_enc` is AES-256-GCM ciphertext
-    // via infrastructure/cipher.ts (same keyring as realm tokens / secrets); the
-    // plaintext never leaves the server. Databases/users/grants are NOT mirrored —
-    // the server's own catalogs are the source of truth (§3), so this is the only
-    // table the subsystem persists.
-    `
+
+    -- Database-server registry (quaykeeper_database_management.md §4). One row per
+    -- owner-connected server; admin_password_enc is AES-256-GCM ciphertext.
+    -- Databases/users/grants are NOT mirrored — the server's own catalogs are the
+    -- source of truth (§3), so this is the only table the subsystem persists.
     CREATE TABLE db_server (
         id                  TEXT PRIMARY KEY,          -- dbsrv_<11 base36>
         name                TEXT NOT NULL UNIQUE,      -- human label ("prod-pg", "shared-mysql")
@@ -438,24 +331,12 @@ const MIGRATIONS: string[] = [
         created_at          TEXT NOT NULL,
         updated_at          TEXT NOT NULL
     );
-    `,
-    // v17 — instances get an optional `project` label: a plain grouping string
-    // shared by many instances (one more way to filter the flat list alongside
-    // tags). Purely organizational — it changes no resolution/fetch behavior.
-    // NULL = unassigned.
-    `
-    ALTER TABLE instance ADD COLUMN project TEXT;
-    CREATE INDEX idx_instance_project ON instance(project);
-    `,
-    // v18 — saved docker-run snippets (the Snippets page). One row per snippet: the
-    // form-built `docker run` recipe is persisted as a JSON `DockerRunSpec` in
-    // `spec` (domain/docker-run.ts owns the shape + validation — SQLite stores it
-    // opaquely, so spec evolution never needs a rebuild). `instance_id` is the
-    // optional Config instance whose resolved variables the generated command
-    // injects at container boot (an inline --entrypoint wrapper against the agent
-    // server); ON DELETE SET NULL so deleting an instance degrades the snippet to
-    // a plain `docker run` instead of deleting it.
-    `
+
+    -- Saved docker-run snippets (the Snippets page). The form-built recipe is a
+    -- JSON DockerRunSpec (domain/docker-run.ts owns shape + validation); instance_id
+    -- is the optional Config instance whose resolved variables the generated command
+    -- injects at container boot — ON DELETE SET NULL degrades the snippet to a
+    -- plain docker run instead of deleting it.
     CREATE TABLE docker_snippet (
         id          TEXT PRIMARY KEY,          -- snip_<11 base36>
         name        TEXT NOT NULL UNIQUE,      -- human label ("redis-cache", "api worker")
@@ -467,14 +348,11 @@ const MIGRATIONS: string[] = [
         updated_at  TEXT NOT NULL
     );
     CREATE INDEX idx_docker_snippet_instance ON docker_snippet(instance_id);
-    `,
-    // v19 — scheduled jobs (the Scheduled tasks page): owner-defined shell / JavaScript
-    // scripts the control-plane host runs on a 5-field cron schedule and/or on demand.
-    // `scheduled_job` is the definition; `job_run` is the append-only execution history
-    // with captured output (ON DELETE CASCADE so deleting a job drops its runs). The
-    // executor + cron ticker live in `services/jobs.ts` / `services/job-scheduler.ts`;
-    // the script is stored opaquely (validated in `domain/job.ts` before it lands).
-    `
+
+    -- Scheduled jobs: owner-defined shell / JavaScript scripts run on a 5-field
+    -- cron schedule and/or on demand; job_run is the append-only execution history
+    -- (ON DELETE CASCADE). Executor + ticker: services/jobs.ts / job-scheduler.ts;
+    -- the script is stored opaquely (domain/job.ts validates before it lands).
     CREATE TABLE scheduled_job (
         id           TEXT PRIMARY KEY,          -- job_<11 base36>
         name         TEXT NOT NULL UNIQUE,      -- human label ("nightly backup")
@@ -505,32 +383,40 @@ const MIGRATIONS: string[] = [
         triggered_by_login TEXT
     );
     CREATE INDEX idx_job_run_job ON job_run(job_id);
-    `,
-    // v20 — log-shipping destinations (log_ides.md §4: Quaykeeper as the control plane).
-    // One row per destination. Quaykeeper is the source of truth (unlike routing
-    // resources, which live in nginxpilot): it owns `scope` (global destinations are
-    // pushed to nginxpilot over Channel A; instance destinations are delivered to
-    // quaykeeper-client via /v1/config) and drift-reconciles the daemon's set against
-    // these rows (G19). The whole destination is stored as an opaque JSON `spec`
-    // (domain/nginxpilot-logdest-fragment.ts owns the shape + validation — SQLite
-    // stores it opaquely so spec evolution never needs a rebuild). SECRETS BY
-    // REFERENCE ONLY: `spec.auth` carries `*_env`/`*_file` reference names, never
-    // secret bytes — nothing to encrypt (the reference-only v1 model, §4.1). `target`
-    // binds a scoped destination to a site hostname / instance id (NULL for global).
-    `
+
+    -- Log shipping (logs_feature.md): log_destination is the reusable owner-defined
+    -- ENDPOINT (name/url/TLS/auth — SECRETS BY REFERENCE ONLY: spec.auth carries
+    -- *_env/*_file names, never secret bytes, so nothing is encrypted); log_binding
+    -- assigns a destination to a log source — an nginxpilot realm's access logs
+    -- (scope 'realm', pushed as a daemon fragment) or a Config instance's app logs
+    -- (scope 'instance', delivered via the agent snapshot) — and carries the
+    -- per-source shaping JSON (labels/filter/parse/tunables, domain LogShaping).
+    -- No SQL FK binding → destination: referential integrity is service-enforced
+    -- (an in-use destination can't be deleted), matching the repo style.
     CREATE TABLE log_destination (
         id          TEXT PRIMARY KEY,          -- logdest_<11 base36>
         name        TEXT NOT NULL UNIQUE,      -- slug [a-z0-9-]+ — the fragment filename component
-        type        TEXT NOT NULL,             -- loki | http | file | stdout
-        scope       TEXT NOT NULL DEFAULT 'global', -- global | site | instance
-        target      TEXT,                      -- site hostname / instance id for a scoped dest; NULL = global
-        enabled     INTEGER NOT NULL DEFAULT 1,
-        spec        TEXT NOT NULL,             -- JSON LogDestination (refs only; domain/nginxpilot-logdest-fragment.ts)
+        type        TEXT NOT NULL,             -- loki | http (push endpoints only)
+        spec        TEXT NOT NULL,             -- JSON DestinationEndpoint (refs only; domain/nginxpilot-logdest-fragment.ts)
         created_by  INTEGER NOT NULL,          -- app_user.github_id
         created_at  TEXT NOT NULL,
         updated_at  TEXT NOT NULL
     );
-    CREATE INDEX idx_log_destination_scope ON log_destination(scope);
+
+    CREATE TABLE log_binding (
+        id             TEXT PRIMARY KEY,           -- logbind_<11 base36>
+        destination_id TEXT NOT NULL,              -- → log_destination.id (service-enforced)
+        scope          TEXT NOT NULL,              -- realm | instance
+        target         TEXT NOT NULL,              -- realm.id | instance.id
+        enabled        INTEGER NOT NULL DEFAULT 1,
+        shaping        TEXT NOT NULL DEFAULT '{}', -- JSON LogShaping (domain/nginxpilot-logdest-fragment.ts)
+        created_by     INTEGER NOT NULL,           -- app_user.github_id
+        created_at     TEXT NOT NULL,
+        updated_at     TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_log_binding_unique ON log_binding(scope, target, destination_id);
+    CREATE INDEX idx_log_binding_target ON log_binding(scope, target);
+    CREATE INDEX idx_log_binding_dest ON log_binding(destination_id);
     `,
 ]
 
@@ -547,11 +433,11 @@ function migrate(db: DatabaseSync): void {
     const applied = new Set(rows.map((r) => r.version))
     const insert = db.prepare('INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)')
     // SQLite requires foreign keys OFF during a CREATE-new / DROP-old / RENAME table
-    // rebuild (migrations v8/v10), and the PRAGMA is a no-op *inside* a transaction — so
-    // toggle it here, around the whole migration run, OUTSIDE any `BEGIN` (D2). Today only
-    // the rebuild migrations need this; doing it for the loop is simplest and harmless,
-    // since migrations either don't touch FKs or are run on a freshly-open connection
-    // before any request. It is restored to ON before the connection serves traffic.
+    // rebuild, and the PRAGMA is a no-op *inside* a transaction — so toggle it here,
+    // around the whole migration run, OUTSIDE any `BEGIN` (D2). No current migration
+    // rebuilds a table, but doing it for the loop is simplest and harmless (a future
+    // rebuild migration then just works), and it is restored to ON before the
+    // connection serves traffic.
     db.exec('PRAGMA foreign_keys = OFF;')
     try {
         for (let i = 0; i < MIGRATIONS.length; i++) {
@@ -559,7 +445,9 @@ function migrate(db: DatabaseSync): void {
             if (applied.has(version)) continue
             db.exec('BEGIN')
             try {
-                db.exec(MIGRATIONS[i])
+                const m = MIGRATIONS[i]
+                if (typeof m === 'function') m(db)
+                else db.exec(m)
                 insert.run(version, new Date().toISOString())
                 db.exec('COMMIT')
             } catch (err) {

--- a/quaykeeper/server/data/repositories/log-binding-repo.ts
+++ b/quaykeeper/server/data/repositories/log-binding-repo.ts
@@ -1,0 +1,158 @@
+// Log-binding repository — all SQL for the `log_binding` table (logs_feature.md
+// §3.2/§6). One row assigns a reusable destination endpoint (`log_destination`)
+// to a log source — an nginxpilot realm's access logs (`scope = 'realm'`) or a
+// Config instance's app logs (`scope = 'instance'`) — and carries the per-source
+// shaping JSON (`LogShaping`: labels/filter/parse/tunables). Referential
+// integrity to `log_destination` is service-enforced (no SQL FK, matching the
+// table's own style); `UNIQUE(scope, target, destination_id)` means a source
+// binds a given destination at most once.
+
+import 'server-only'
+import { prep, getRow, allRows } from '@/server/data/db'
+import type { LogBindingScope, LogShaping } from '@/server/domain/nginxpilot-logdest-fragment'
+
+/** One stored binding: destination × source + the shaping half of the old spec. */
+export interface StoredLogBinding {
+    id: string
+    destinationId: string
+    scope: LogBindingScope
+    /** `realm.id` (realm scope) | `instance.id` (instance scope). */
+    target: string
+    enabled: boolean
+    shaping: LogShaping
+    createdBy: number
+    createdAt: string
+    updatedAt: string
+}
+
+interface Raw {
+    id: string
+    destination_id: string
+    scope: string
+    target: string
+    enabled: number
+    shaping: string
+    created_by: number
+    created_at: string
+    updated_at: string
+}
+
+function map(r: Raw): StoredLogBinding {
+    return {
+        id: r.id,
+        destinationId: r.destination_id,
+        scope: r.scope as LogBindingScope,
+        target: r.target,
+        enabled: r.enabled !== 0,
+        shaping: JSON.parse(r.shaping) as LogShaping,
+        createdBy: r.created_by,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+    }
+}
+
+export function list(): StoredLogBinding[] {
+    return allRows<Raw>('SELECT * FROM log_binding ORDER BY scope, target, created_at').map(map)
+}
+
+export function listByDestination(destinationId: string): StoredLogBinding[] {
+    return allRows<Raw>(
+        'SELECT * FROM log_binding WHERE destination_id = ? ORDER BY scope, target',
+        destinationId,
+    ).map(map)
+}
+
+export function listByTarget(scope: LogBindingScope, target: string): StoredLogBinding[] {
+    return allRows<Raw>(
+        'SELECT * FROM log_binding WHERE scope = ? AND target = ? ORDER BY created_at',
+        scope,
+        target,
+    ).map(map)
+}
+
+/** A realm's bindings — what its nginxpilot daemon should be shipping. */
+export function listRealm(realmId: string): StoredLogBinding[] {
+    return listByTarget('realm', realmId)
+}
+
+/** An instance's bindings — what its quaykeeper-client snapshot delivers. */
+export function listInstance(instanceId: string): StoredLogBinding[] {
+    return listByTarget('instance', instanceId)
+}
+
+export function byId(id: string): StoredLogBinding | undefined {
+    const r = getRow<Raw>('SELECT * FROM log_binding WHERE id = ?', id)
+    return r ? map(r) : undefined
+}
+
+/** The binding for one (source, destination) pair — the UNIQUE(scope, target, destination_id) lookup. */
+export function bySource(
+    scope: LogBindingScope,
+    target: string,
+    destinationId: string,
+): StoredLogBinding | undefined {
+    const r = getRow<Raw>(
+        'SELECT * FROM log_binding WHERE scope = ? AND target = ? AND destination_id = ?',
+        scope,
+        target,
+        destinationId,
+    )
+    return r ? map(r) : undefined
+}
+
+export function insert(row: StoredLogBinding): void {
+    prep(
+        `INSERT INTO log_binding (id, destination_id, scope, target, enabled, shaping, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+        row.id,
+        row.destinationId,
+        row.scope,
+        row.target,
+        row.enabled ? 1 : 0,
+        JSON.stringify(row.shaping),
+        row.createdBy,
+        row.createdAt,
+        row.updatedAt,
+    )
+}
+
+/** Replace a binding's mutable fields (source + destination are immutable — delete and rebind). */
+export function update(
+    id: string,
+    fields: { enabled?: boolean; shaping?: LogShaping; updatedAt: string },
+): void {
+    const sets: string[] = []
+    const params: (string | number)[] = []
+    if (fields.enabled !== undefined) {
+        sets.push('enabled = ?')
+        params.push(fields.enabled ? 1 : 0)
+    }
+    if (fields.shaping !== undefined) {
+        sets.push('shaping = ?')
+        params.push(JSON.stringify(fields.shaping))
+    }
+    sets.push('updated_at = ?')
+    params.push(fields.updatedAt)
+    params.push(id)
+    prep(`UPDATE log_binding SET ${sets.join(', ')} WHERE id = ?`).run(...params)
+}
+
+export function remove(id: string): void {
+    prep('DELETE FROM log_binding WHERE id = ?').run(id)
+}
+
+/** Drop every binding for a source — the realm-delete cascade (D5). */
+export function removeByTarget(scope: LogBindingScope, target: string): void {
+    prep('DELETE FROM log_binding WHERE scope = ? AND target = ?').run(scope, target)
+}
+
+/** How many bindings reference a destination — the destination-delete guard. */
+export function countByDestination(destinationId: string): number {
+    return (
+        getRow<{ n: number }>(
+            'SELECT COUNT(*) AS n FROM log_binding WHERE destination_id = ?',
+            destinationId,
+        )?.n ?? 0
+    )
+}

--- a/quaykeeper/server/data/repositories/log-destination-repo.ts
+++ b/quaykeeper/server/data/repositories/log-destination-repo.ts
@@ -1,29 +1,23 @@
-// Log-destination registry repository — all SQL for the `log_destination` table
-// (log_ides.md §4). Quaykeeper is the source of truth for log destinations
-// (unlike routing resources, which live in nginxpilot): this table drives what
-// gets pushed to the daemon (global scope) or delivered to quaykeeper-client
-// (instance scope), and the drift reconciler (G19) diffs the daemon's live set
-// against these rows. The destination `spec` is stored as opaque JSON and carries
+// Log-destination registry repository — all SQL for the `log_destination` table.
+// Since the endpoint/binding split (logs_feature.md) a row is a reusable,
+// owner-defined push *endpoint* (name/url/TLS/auth — the domain
+// `DestinationEndpoint`); where it applies and how the stream is shaped live on
+// `log_binding` rows (log-binding-repo.ts). (Databases created before the
+// migration squash may still carry the pre-split `scope`/`target`/`enabled`
+// columns — DEPRECATED, never read or written here.) The `spec` JSON carries
 // secret material BY REFERENCE ONLY (`*_env`/`*_file`), so no column is encrypted.
 
 import 'server-only'
 import { prep, getRow, allRows } from '@/server/data/db'
-import type { LogDestination } from '@/server/domain/nginxpilot-logdest-fragment'
+import type { DestinationEndpoint } from '@/server/domain/nginxpilot-logdest-fragment'
 
-/** Where a destination applies. `global` pushes to nginxpilot; `instance` is delivered to a client. */
-export type LogDestScope = 'global' | 'site' | 'instance'
-
-/** The stored destination: identity + scope binding + the validated JSON spec. */
+/** The stored destination endpoint: identity + the validated endpoint-only JSON spec. */
 export interface StoredLogDestination {
     id: string
     name: string
     type: string
-    scope: LogDestScope
-    /** Site hostname / instance id for a scoped destination; undefined for global. */
-    target?: string
-    enabled: boolean
-    /** The full destination as `POST /log-destinations` / a `logs:` snapshot entry would carry it. */
-    spec: LogDestination
+    /** Endpoint fields only (url/tenant/TLS/auth) — shaping lives on bindings. */
+    spec: DestinationEndpoint
     createdBy: number
     createdAt: string
     updatedAt: string
@@ -33,9 +27,6 @@ interface Raw {
     id: string
     name: string
     type: string
-    scope: string
-    target: string | null
-    enabled: number
     spec: string
     created_by: number
     created_at: string
@@ -47,10 +38,7 @@ function map(r: Raw): StoredLogDestination {
         id: r.id,
         name: r.name,
         type: r.type,
-        scope: r.scope as LogDestScope,
-        target: r.target ?? undefined,
-        enabled: r.enabled !== 0,
-        spec: JSON.parse(r.spec) as LogDestination,
+        spec: JSON.parse(r.spec) as DestinationEndpoint,
         createdBy: r.created_by,
         createdAt: r.created_at,
         updatedAt: r.updated_at,
@@ -59,10 +47,6 @@ function map(r: Raw): StoredLogDestination {
 
 export function list(): StoredLogDestination[] {
     return allRows<Raw>('SELECT * FROM log_destination ORDER BY name').map(map)
-}
-
-export function listByScope(scope: LogDestScope): StoredLogDestination[] {
-    return allRows<Raw>('SELECT * FROM log_destination WHERE scope = ? ORDER BY name', scope).map(map)
 }
 
 export function byId(id: string): StoredLogDestination | undefined {
@@ -77,15 +61,12 @@ export function byName(name: string): StoredLogDestination | undefined {
 
 export function insert(row: StoredLogDestination): void {
     prep(
-        `INSERT INTO log_destination (id, name, type, scope, target, enabled, spec, created_by, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO log_destination (id, name, type, spec, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
     ).run(
         row.id,
         row.name,
         row.type,
-        row.scope,
-        row.target ?? null,
-        row.enabled ? 1 : 0,
         JSON.stringify(row.spec),
         row.createdBy,
         row.createdAt,
@@ -98,30 +79,15 @@ export function update(
     id: string,
     fields: {
         type?: string
-        scope?: LogDestScope
-        target?: string | null
-        enabled?: boolean
-        spec?: LogDestination
+        spec?: DestinationEndpoint
         updatedAt: string
     },
 ): void {
     const sets: string[] = []
-    const params: (string | number | null)[] = []
+    const params: (string | number)[] = []
     if (fields.type !== undefined) {
         sets.push('type = ?')
         params.push(fields.type)
-    }
-    if (fields.scope !== undefined) {
-        sets.push('scope = ?')
-        params.push(fields.scope)
-    }
-    if (fields.target !== undefined) {
-        sets.push('target = ?')
-        params.push(fields.target)
-    }
-    if (fields.enabled !== undefined) {
-        sets.push('enabled = ?')
-        params.push(fields.enabled ? 1 : 0)
     }
     if (fields.spec !== undefined) {
         sets.push('spec = ?')

--- a/quaykeeper/server/domain/docker-run.ts
+++ b/quaykeeper/server/domain/docker-run.ts
@@ -2,8 +2,8 @@
 // `DockerRunSpec` shape, its normalization + validation, and the `docker run`
 // command renderer — including the optional Quaykeeper-variable injection that
 // rewrites the container entrypoint inline (`--entrypoint /bin/sh … -c '…'`) to
-// pull the instance's resolved env from the agent server at boot and `exec` the
-// real command.
+// run the install.sh bootstrap: fetch the quaykeeper-client binary at boot, pull
+// the instance's resolved env from the agent server, and `exec` the real command.
 //
 // PURE and isomorphic (no `server-only`, no I/O): the client imports it for the
 // live command preview + inline form validation, the service for the
@@ -306,27 +306,29 @@ export interface BuildContext {
 }
 
 /**
- * The inline bootstrap the injecting variant runs as PID 1: fetch the instance's
- * resolved env from the agent server as shell `export` lines (`?format=shell` —
- * single-quoted, so values never re-expand), source it, then `exec` the real
- * command. Fails closed: `set -e` aborts the container if the fetch fails, so an
- * app never boots half-configured.
+ * The inline bootstrap the injecting variant runs as PID 1: fetch the public
+ * `/v1/install.sh` from the agent server, pipe it to `sh`, and hand it
+ * `exec -- <command>`. install.sh downloads the matching `quaykeeper-client`
+ * binary, which pulls the instance's resolved env (authenticated with the three
+ * QUAYKEEPER_* env vars set below) and `exec`s the real command as PID 1. Fails
+ * closed: the client aborts the container if the fetch fails, so an app never
+ * boots half-configured. curl/wget here only fetch the script — install.sh
+ * auto-detects the tool it uses to download the binary. This is the same
+ * bootstrap the instance Settings tab documents as a Dockerfile ENTRYPOINT.
  */
 function injectScript(spec: DockerRunSpec): string {
-    const url = '"$QUAYKEEPER_URL/v1/env?format=shell"'
-    const fetchCmd =
-        spec.inject?.tool === 'wget'
-            ? `wget -q --header "X-Quaykeeper-Instance: $QUAYKEEPER_INSTANCE" --header "Authorization: Bearer $QUAYKEEPER_SECRET" -O "$f" ${url}`
-            : `curl -fsSL -H "X-Quaykeeper-Instance: $QUAYKEEPER_INSTANCE" -H "Authorization: Bearer $QUAYKEEPER_SECRET" -o "$f" ${url}`
-    return `set -e; f=$(mktemp); ${fetchCmd}; . "$f"; rm -f "$f"; exec ${spec.command}`
+    const url = '"$QUAYKEEPER_URL/v1/install.sh"'
+    const fetchCmd = spec.inject?.tool === 'wget' ? `wget -qO- ${url}` : `curl -fsSL ${url}`
+    return `${fetchCmd} | sh -s -- exec -- ${spec.command}`
 }
 
 /**
  * Render the multi-line `docker run` command for a (normalized, valid) spec.
- * With injection, the entrypoint is overridden inline: the three QUAYKEEPER_* env
- * vars point the bootstrap at the agent server, and `QUAYKEEPER_SECRET` is
- * rendered as `"$QUAYKEEPER_SECRET"` — resolved by the OPERATOR'S shell at paste
- * time, so the fetch secret is never stored in the snippet or the command text.
+ * With injection, the entrypoint is overridden inline to run the install.sh
+ * bootstrap ({@link injectScript}): the three QUAYKEEPER_* env vars point the
+ * client at the agent server, and `QUAYKEEPER_SECRET` is rendered as
+ * `"$QUAYKEEPER_SECRET"` — resolved by the OPERATOR'S shell at paste time, so the
+ * fetch secret is never stored in the snippet or the command text.
  */
 export function buildDockerRun(spec: DockerRunSpec, ctx: BuildContext = {}): string {
     const args: string[] = []

--- a/quaykeeper/server/domain/nginxpilot-logdest-fragment.ts
+++ b/quaykeeper/server/domain/nginxpilot-logdest-fragment.ts
@@ -296,6 +296,81 @@ function parseFilter(input: unknown): Check<Record<string, string[]> | undefined
     return { ok: true, value: Object.keys(out).length ? out : undefined }
 }
 
+/** The push-endpoint field subset shared by `parseLogDestination` and `parseDestinationEndpoint`. */
+interface EndpointFields {
+    url: string
+    tenant?: string
+    allow_insecure?: boolean
+    ca_file?: string
+    insecure_skip_verify?: boolean
+    auth?: LogAuth
+}
+
+/** Validate the shared push-endpoint block (URL/TLS/auth/tenant) for a loki/http destination. */
+function parseEndpointFields(o: Record<string, unknown>, type: 'loki' | 'http'): Check<EndpointFields> {
+    const url = optStr(o.url)
+    if (!url) return reject('url_required', `url is required for type: ${type}`)
+    let parsed: URL
+    try {
+        parsed = new URL(url)
+    } catch {
+        return reject('bad_url', `url ${JSON.stringify(url)} is not a valid URL`)
+    }
+    const allowInsecure = o.allow_insecure === true
+    if (parsed.protocol === 'http:') {
+        if (!allowInsecure) return reject('insecure_url', 'http:// URLs require allow_insecure: true (https:// is the default)')
+    } else if (parsed.protocol !== 'https:') {
+        return reject('bad_scheme', `url ${JSON.stringify(url)}: must be https:// (or http:// with allow_insecure: true)`)
+    }
+    const value: EndpointFields = { url }
+    if (allowInsecure) value.allow_insecure = true
+    const caFile = optStr(o.ca_file)
+    if (caFile) value.ca_file = caFile
+    if (o.insecure_skip_verify === true) {
+        if (!allowInsecure) return reject('skip_verify', 'insecure_skip_verify requires allow_insecure: true')
+        value.insecure_skip_verify = true
+    }
+
+    const auth = parseLogAuth(o.auth)
+    if (!auth.ok) return auth
+    if (auth.value) value.auth = auth.value
+
+    if (type === 'http') {
+        if (optStr(o.tenant)) return reject('http_tenant', 'tenant only applies to type: loki')
+    } else {
+        const tenant = optStr(o.tenant)
+        if (tenant) value.tenant = tenant
+    }
+    return { ok: true, value }
+}
+
+/** The shipping-tunable subset shared by `parseLogDestination` and `parseShaping`. */
+type ShippingTunables = Pick<LogDestination, 'sample' | 'batch_size' | 'flush_interval' | 'max_retries' | 'buffer_size'>
+
+/** Validate the shipping tunables (sample/batch/flush/retries/buffer). */
+function parseTunables(o: Record<string, unknown>): Check<ShippingTunables> {
+    const value: ShippingTunables = {}
+    if (o.sample !== undefined && o.sample !== null && o.sample !== '') {
+        const s = typeof o.sample === 'string' ? Number(o.sample) : o.sample
+        if (typeof s !== 'number' || !Number.isFinite(s) || s <= 0 || s > 1) {
+            return reject('bad_sample', 'sample must be a number in (0, 1]')
+        }
+        value.sample = s
+    }
+    const batchSize = optInt(o.batch_size)
+    if (!batchSize.ok) return reject('bad_batch_size', 'batch_size must be a non-negative integer')
+    if (batchSize.value !== undefined) value.batch_size = batchSize.value
+    const maxRetries = optInt(o.max_retries)
+    if (!maxRetries.ok) return reject('bad_max_retries', 'max_retries must be a non-negative integer')
+    if (maxRetries.value !== undefined) value.max_retries = maxRetries.value
+    const bufferSize = optInt(o.buffer_size)
+    if (!bufferSize.ok) return reject('bad_buffer_size', 'buffer_size must be a non-negative integer')
+    if (bufferSize.value !== undefined) value.buffer_size = bufferSize.value
+    const flushInterval = optStr(o.flush_interval)
+    if (flushInterval) value.flush_interval = flushInterval
+    return { ok: true, value }
+}
+
 /**
  * Validate + normalize a log destination (the write/test body). Mirrors
  * nginxpilot's `validateLogDestination`: type-specific field sanity, secrets by
@@ -321,39 +396,13 @@ export function parseLogDestination(input: unknown): Check<LogDestination> {
     const isPush = type === 'loki' || type === 'http'
 
     if (isPush) {
-        const url = optStr(o.url)
-        if (!url) return reject('url_required', `url is required for type: ${type}`)
-        let parsed: URL
-        try {
-            parsed = new URL(url)
-        } catch {
-            return reject('bad_url', `url ${JSON.stringify(url)} is not a valid URL`)
-        }
-        const allowInsecure = o.allow_insecure === true
-        if (parsed.protocol === 'http:') {
-            if (!allowInsecure) return reject('insecure_url', 'http:// URLs require allow_insecure: true (https:// is the default)')
-        } else if (parsed.protocol !== 'https:') {
-            return reject('bad_scheme', `url ${JSON.stringify(url)}: must be https:// (or http:// with allow_insecure: true)`)
-        }
-        value.url = url
-        if (allowInsecure) value.allow_insecure = true
-        const caFile = optStr(o.ca_file)
-        if (caFile) value.ca_file = caFile
-        if (o.insecure_skip_verify === true) {
-            if (!allowInsecure) return reject('skip_verify', 'insecure_skip_verify requires allow_insecure: true')
-            value.insecure_skip_verify = true
-        }
-
-        const auth = parseLogAuth(o.auth)
-        if (!auth.ok) return auth
-        if (auth.value) value.auth = auth.value
+        const endpoint = parseEndpointFields(o, type as 'loki' | 'http')
+        if (!endpoint.ok) return endpoint
+        Object.assign(value, endpoint.value)
 
         if (type === 'http') {
-            if (optStr(o.tenant)) return reject('http_tenant', 'tenant only applies to type: loki')
             if (asObject(o.labels)) return reject('http_labels', 'labels only apply to type: loki (an http collector receives the full JSON lines)')
         } else {
-            const tenant = optStr(o.tenant)
-            if (tenant) value.tenant = tenant
             const labels = parseLabels(o.labels)
             if (!labels.ok) return labels
             if (labels.value) value.labels = labels.value
@@ -394,27 +443,166 @@ export function parseLogDestination(input: unknown): Check<LogDestination> {
     if (!parse.ok) return parse
     if (parse.value) value.parse = parse.value
 
-    if (o.sample !== undefined && o.sample !== null && o.sample !== '') {
-        const s = typeof o.sample === 'string' ? Number(o.sample) : o.sample
-        if (typeof s !== 'number' || !Number.isFinite(s) || s <= 0 || s > 1) {
-            return reject('bad_sample', 'sample must be a number in (0, 1]')
-        }
-        value.sample = s
-    }
-
-    const batchSize = optInt(o.batch_size)
-    if (!batchSize.ok) return reject('bad_batch_size', 'batch_size must be a non-negative integer')
-    if (batchSize.value !== undefined) value.batch_size = batchSize.value
-    const maxRetries = optInt(o.max_retries)
-    if (!maxRetries.ok) return reject('bad_max_retries', 'max_retries must be a non-negative integer')
-    if (maxRetries.value !== undefined) value.max_retries = maxRetries.value
-    const bufferSize = optInt(o.buffer_size)
-    if (!bufferSize.ok) return reject('bad_buffer_size', 'buffer_size must be a non-negative integer')
-    if (bufferSize.value !== undefined) value.buffer_size = bufferSize.value
-    const flushInterval = optStr(o.flush_interval)
-    if (flushInterval) value.flush_interval = flushInterval
+    const tunables = parseTunables(o)
+    if (!tunables.ok) return tunables
+    Object.assign(value, tunables.value)
 
     return { ok: true, value }
+}
+
+// ── destination endpoint + binding shaping (log destinations redesign) ───────────
+// Quaykeeper stores destinations split in two: a reusable owner-defined *endpoint*
+// (`DestinationEndpoint`, the `log_destination` row) and a per-source *binding*
+// carrying the shaping config (`LogShaping`, the `log_binding` row). The nginxpilot
+// and quaykeeper-client wire contract is untouched — `assembleSpec` reassembles the
+// two halves into the exact `LogDestination` the daemon fragment / agent snapshot
+// always carried.
+
+/** Owner endpoint types — push endpoints only (file/stdout have no URL/CA/auth). */
+export type DestinationEndpointType = 'loki' | 'http'
+
+/**
+ * A reusable, owner-defined push endpoint: identity + connection + auth (by
+ * reference). No scope, no target, no filters, no labels, no shipping tunables —
+ * those live on the binding (`LogShaping`).
+ */
+export interface DestinationEndpoint {
+    /** Identity + fragment-filename component — `[a-z0-9-]+`, immutable, UNIQUE. */
+    name: string
+    type: DestinationEndpointType
+    /** Push endpoint. `https://` required unless `allow_insecure`. */
+    url: string
+    /** Loki `X-Scope-OrgID` tenant (loki only; endpoint identity, D2). */
+    tenant?: string
+    ca_file?: string
+    allow_insecure?: boolean
+    insecure_skip_verify?: boolean
+    /** Reference names only (`*_env` / `*_file`) — never secret bytes. */
+    auth?: LogAuth
+}
+
+/** Where a binding applies: an nginxpilot realm's access logs, or a Config instance's app logs. */
+export type LogBindingScope = 'realm' | 'instance'
+
+/**
+ * The per-source shaping half of a binding: what to ship (filter/sample), how to
+ * label it (loki only), how to structure it (parse — instance scope only), and the
+ * shipping tunables.
+ */
+export interface LogShaping {
+    labels?: Record<string, string>
+    filter?: Record<string, string[]>
+    /** Instance scope only — rejected on realm bindings (edge access logs are already JSON). */
+    parse?: string[]
+    sample?: number
+    batch_size?: number
+    flush_interval?: string
+    max_retries?: number
+    buffer_size?: number
+}
+
+/**
+ * Validate + normalize an owner endpoint (the `/admin/log-destinations` write body).
+ * A strict subset of `parseLogDestination`: name/type/url/tenant/TLS/auth only —
+ * shaping fields are not accepted here (they belong to bindings).
+ */
+export function parseDestinationEndpoint(input: unknown): Check<DestinationEndpoint> {
+    const o = asObject(input)
+    if (!o) return reject('not_object', 'log destination must be an object')
+
+    const name = optStr(o.name)
+    if (!name) return reject('name_required', 'log destination name is required')
+    if (!LOGDEST_NAME.test(name)) return reject('bad_name', 'name must match [a-z0-9-]+ (it becomes the fragment filename)')
+
+    const type = optStr(o.type)
+    if (!type) return reject('type_required', 'type is required (loki | http)')
+    if (type !== 'loki' && type !== 'http') {
+        return reject('bad_type', 'type must be loki | http (push endpoints only)')
+    }
+
+    const endpoint = parseEndpointFields(o, type)
+    if (!endpoint.ok) return endpoint
+    return { ok: true, value: { name, type, ...endpoint.value } }
+}
+
+/**
+ * Validate + normalize a binding's shaping config. Labels are loki-only; parse
+ * templates are instance-scope-only (nginxpilot access logs are already JSON).
+ */
+export function parseShaping(
+    input: unknown,
+    opts: { scope: LogBindingScope; type: DestinationEndpointType },
+): Check<LogShaping> {
+    if (input === undefined || input === null) return { ok: true, value: {} }
+    const o = asObject(input)
+    if (!o) return reject('bad_shaping', 'shaping must be an object')
+
+    const value: LogShaping = {}
+
+    if (opts.type === 'loki') {
+        const labels = parseLabels(o.labels)
+        if (!labels.ok) return labels
+        if (labels.value) value.labels = labels.value
+    } else if (asObject(o.labels)) {
+        return reject('http_labels', 'labels only apply to loki destinations (an http collector receives the full JSON lines)')
+    }
+
+    const filter = parseFilter(o.filter)
+    if (!filter.ok) return filter
+    if (filter.value) value.filter = filter.value
+
+    const parse = parseTemplates(o.parse)
+    if (!parse.ok) return parse
+    if (parse.value) {
+        if (opts.scope === 'realm') {
+            return reject('parse_realm', 'parse templates apply to instance bindings only (nginxpilot access logs are already JSON)')
+        }
+        value.parse = parse.value
+    }
+
+    const tunables = parseTunables(o)
+    if (!tunables.ok) return tunables
+    Object.assign(value, tunables.value)
+
+    return { ok: true, value }
+}
+
+/**
+ * Reassemble a stored endpoint + a binding's shaping into the wire-shape
+ * `LogDestination` nginxpilot / quaykeeper-client consume — then re-run
+ * `parseLogDestination` on the result (defense in depth). `parse` only survives
+ * for instance scope. Throws when the merged spec fails validation (both halves
+ * were validated at write time, so this indicates corrupt stored data).
+ */
+export function assembleSpec(
+    dest: DestinationEndpoint,
+    binding: { scope: LogBindingScope; enabled: boolean; shaping: LogShaping },
+): LogDestination {
+    const s = binding.shaping
+    const merged: Record<string, unknown> = {
+        name: dest.name,
+        type: dest.type,
+        enabled: binding.enabled,
+        url: dest.url,
+        tenant: dest.tenant,
+        ca_file: dest.ca_file,
+        allow_insecure: dest.allow_insecure,
+        insecure_skip_verify: dest.insecure_skip_verify,
+        auth: dest.auth,
+        labels: s.labels,
+        filter: s.filter,
+        parse: binding.scope === 'instance' ? s.parse : undefined,
+        sample: s.sample,
+        batch_size: s.batch_size,
+        flush_interval: s.flush_interval,
+        max_retries: s.max_retries,
+        buffer_size: s.buffer_size,
+    }
+    const checked = parseLogDestination(merged)
+    if (!checked.ok) {
+        throw new Error(`[quaykeeper] assembled log destination "${dest.name}" failed validation: ${checked.message}`)
+    }
+    return checked.value
 }
 
 // ── YAML rendering (the POST body; mirrors domain/streams.ts) ───────────────────

--- a/quaykeeper/server/infrastructure/ids.ts
+++ b/quaykeeper/server/infrastructure/ids.ts
@@ -28,4 +28,5 @@ export const ID = {
     job: () => newId('job'),
     jobRun: () => newId('run'),
     logDestination: () => newId('logdest'),
+    logBinding: () => newId('logbind'),
 }

--- a/quaykeeper/server/services/agent-fetch.ts
+++ b/quaykeeper/server/services/agent-fetch.ts
@@ -12,7 +12,8 @@ import * as flagRepo from '@/server/data/repositories/flag-repo'
 import * as instanceRepo from '@/server/data/repositories/instance-repo'
 import * as auditRepo from '@/server/data/repositories/audit-repo'
 import * as logDestRepo from '@/server/data/repositories/log-destination-repo'
-import type { LogDestination } from '@/server/domain/nginxpilot-logdest-fragment'
+import * as logBindingRepo from '@/server/data/repositories/log-binding-repo'
+import { assembleSpec, type LogDestination } from '@/server/domain/nginxpilot-logdest-fragment'
 
 /** Deterministic JSON stringify (sorted object keys) for a stable ETag. */
 function canonical(v: unknown): string {
@@ -53,13 +54,23 @@ function buildSnapshot(instanceId: string): AgentSnapshot {
     const flags: Record<string, { enabled: boolean }> = {}
     for (const f of flagRepo.listByInstance(instanceId)) flags[f.key] = { enabled: f.enabled }
 
-    // Instance-scoped log destinations targeting THIS instance only (G28: a
-    // destination's credentials reach only the instances that opted into it). The
-    // stored spec is already the client wire shape (secrets by reference).
-    const destinations = logDestRepo
-        .listByScope('instance')
-        .filter((d) => d.enabled && d.target === instanceId)
-        .map((d) => d.spec)
+    // Log bindings targeting THIS instance only (G28: a destination's credentials
+    // reach only the instances that opted into it). The endpoint is read fresh and
+    // reassembled with the binding's shaping into the client wire shape (secrets by
+    // reference), so an endpoint edit reaches instances via the version-hash bump.
+    const destinations = logBindingRepo
+        .listInstance(instanceId)
+        .filter((b) => b.enabled)
+        .map((b) => {
+            const dest = logDestRepo.byId(b.destinationId)
+            if (!dest) return null
+            try {
+                return assembleSpec(dest.spec, b)
+            } catch {
+                return null // corrupt stored halves — skip rather than break the snapshot
+            }
+        })
+        .filter((d): d is LogDestination => d !== null)
     const logs: AgentLogsConfig | undefined = destinations.length ? { destinations } : undefined
 
     // `logs` folds into the version hash so a destination/filter change bumps the

--- a/quaykeeper/server/services/log-bindings.ts
+++ b/quaykeeper/server/services/log-bindings.ts
@@ -1,0 +1,429 @@
+// Log-binding service (logs_feature.md §7) — assigns a reusable destination
+// endpoint (services/log-destinations.ts) to a log source and owns every daemon
+// push/retract for the pipeline:
+//
+//   • realm binding    — "this NGINX server ships its access logs to destination X."
+//     Set from the Servers page; the assembled `LogDestination` fragment is pushed
+//     to *that* realm's nginxpilot (`realms.clientFor(realmId)` — never the
+//     cookie-resolved active realm) over Channel A.
+//   • instance binding — "this Config instance ships its app logs to destination X."
+//     Set from the instance's Logs tab; stored only — quaykeeper-client picks it up
+//     via the agent snapshot (services/agent-fetch.ts), whose version hash folds the
+//     assembled spec, so no daemon call happens here.
+//
+// Realm bindings are owner-only (routes gate `authorize('owner')`); instance
+// bindings are maintainer-level (D3) — maintainers *choose* from owner-defined
+// endpoints, they can't define one. `reconcileRealm` replaces the old global
+// drift reconcile (G19), now correctly scoped per realm.
+
+import 'server-only'
+import * as auditRepo from '@/server/data/repositories/audit-repo'
+import * as logDestRepo from '@/server/data/repositories/log-destination-repo'
+import * as logBindingRepo from '@/server/data/repositories/log-binding-repo'
+import type { StoredLogBinding } from '@/server/data/repositories/log-binding-repo'
+import * as instanceRepo from '@/server/data/repositories/instance-repo'
+import * as realmRepo from '@/server/data/repositories/realm-repo'
+import * as realms from '@/server/services/realms'
+import { RealmError } from '@/server/services/realms'
+import { NginxpilotError, type NginxpilotClient } from '@/server/infrastructure/nginxpilot'
+import {
+    assembleSpec,
+    parseShaping,
+    logqlSelector,
+    type DestinationEndpointType,
+    type LogDestination,
+    type LogShaping,
+} from '@/server/domain/nginxpilot-logdest-fragment'
+import { ID } from '@/server/infrastructure/ids'
+import { slog } from '@/server/infrastructure/server-log'
+
+/** A refusal Quaykeeper raises before touching nginxpilot (bad shaping, unknown ids, duplicates). */
+export class LogBindingError extends Error {
+    constructor(
+        message: string,
+        public code: string,
+        public status: 400 | 404 | 409,
+    ) {
+        super(message)
+        this.name = 'LogBindingError'
+    }
+}
+
+/** The acting user, derived from the session — attributed on every audit entry. */
+export interface LogBindingActor {
+    githubId: number
+    login: string
+}
+
+/**
+ * A binding as the UI sees it: the binding row joined with its destination's
+ * identity (name/type/url so tables render without a second fetch) + the LogQL
+ * selector its labels resolve to (loki only — the preview pane).
+ */
+export interface LogBindingDto {
+    id: string
+    destinationId: string
+    destinationName: string
+    destinationType: string
+    destinationUrl: string
+    scope: 'realm' | 'instance'
+    target: string
+    enabled: boolean
+    shaping: LogShaping
+    logql: string
+    createdAt: string
+    updatedAt: string
+}
+
+function audit(actor: LogBindingActor, action: string, detail: string, meta?: unknown): void {
+    auditRepo.append({ githubId: actor.githubId, login: actor.login, action, site: null, detail, meta })
+}
+
+function toDto(binding: StoredLogBinding, dest: { id: string; name: string; type: string; spec: { url: string } }): LogBindingDto {
+    return {
+        id: binding.id,
+        destinationId: dest.id,
+        destinationName: dest.name,
+        destinationType: dest.type,
+        destinationUrl: dest.spec.url,
+        scope: binding.scope,
+        target: binding.target,
+        enabled: binding.enabled,
+        shaping: binding.shaping,
+        logql:
+            dest.type === 'loki'
+                ? logqlSelector({ name: dest.name, type: 'loki', labels: binding.shaping.labels })
+                : '',
+        createdAt: binding.createdAt,
+        updatedAt: binding.updatedAt,
+    }
+}
+
+/** Join one binding with its destination; undefined when the endpoint row is gone (shouldn't happen — deletes are guarded). */
+function joined(binding: StoredLogBinding): LogBindingDto | undefined {
+    const dest = logDestRepo.byId(binding.destinationId)
+    return dest ? toDto(binding, dest) : undefined
+}
+
+export function listForRealm(realmId: string): LogBindingDto[] {
+    return logBindingRepo
+        .listRealm(realmId)
+        .map(joined)
+        .filter((d): d is LogBindingDto => !!d)
+}
+
+export function listForInstance(instanceId: string): LogBindingDto[] {
+    return logBindingRepo
+        .listInstance(instanceId)
+        .map(joined)
+        .filter((d): d is LogBindingDto => !!d)
+}
+
+/** Parse + validate a binding request's common half (destination + shaping). */
+function parseBindingInput(
+    input: { destinationId?: unknown; enabled?: unknown; shaping?: unknown },
+    scope: 'realm' | 'instance',
+): { destinationId: string; enabled: boolean; shaping: LogShaping } {
+    const destinationId = typeof input.destinationId === 'string' ? input.destinationId.trim() : ''
+    if (!destinationId) {
+        throw new LogBindingError('"destinationId" is required', 'destination_required', 400)
+    }
+    const dest = logDestRepo.byId(destinationId)
+    if (!dest) throw new LogBindingError('log destination not found', 'destination_not_found', 404)
+
+    const checked = parseShaping(input.shaping, { scope, type: dest.type as DestinationEndpointType })
+    if (!checked.ok) throw new LogBindingError(checked.message, `shaping_${checked.reason}`, 400)
+
+    return { destinationId, enabled: input.enabled !== false, shaping: checked.value }
+}
+
+// ── realm bindings (owner; daemon push/retract lives here) ──────────────────────
+
+/**
+ * Set THE realm's log binding (the Servers-page modal is one-destination-per-realm):
+ * upsert the row for the chosen destination, retract + drop any binding this realm
+ * held on a *different* destination, then push/retract the daemon fragment on that
+ * realm's own client. If the daemon rejects the fragment the row change is rolled
+ * back, so the DB never holds a realm binding the daemon refused (mirrors the old
+ * global-create rollback).
+ */
+export async function setRealmBinding(
+    actor: LogBindingActor,
+    realmId: string,
+    input: { destinationId?: unknown; enabled?: unknown; shaping?: unknown },
+): Promise<LogBindingDto> {
+    if (!realmRepo.byId(realmId)) throw new LogBindingError('realm not found', 'realm_not_found', 404)
+    const { destinationId, enabled, shaping } = parseBindingInput(input, 'realm')
+    const dest = logDestRepo.byId(destinationId)!
+    const client = realms.clientFor(realmId)
+
+    // One binding per realm in the UI: switching destination retracts + drops the old one.
+    for (const other of logBindingRepo.listRealm(realmId)) {
+        if (other.destinationId === destinationId) continue
+        const otherDest = logDestRepo.byId(other.destinationId)
+        if (otherDest) await client.removeLogDestination(otherDest.name).catch(() => undefined)
+        logBindingRepo.remove(other.id)
+    }
+
+    const now = new Date().toISOString()
+    const previous = logBindingRepo.bySource('realm', realmId, destinationId)
+    let row: StoredLogBinding
+    if (previous) {
+        logBindingRepo.update(previous.id, { enabled, shaping, updatedAt: now })
+        row = { ...previous, enabled, shaping, updatedAt: now }
+    } else {
+        row = {
+            id: ID.logBinding(),
+            destinationId,
+            scope: 'realm',
+            target: realmId,
+            enabled,
+            shaping,
+            createdBy: actor.githubId,
+            createdAt: now,
+            updatedAt: now,
+        }
+        logBindingRepo.insert(row)
+    }
+
+    try {
+        if (enabled) {
+            await client.writeLogDestination(assembleSpec(dest.spec, row))
+        } else {
+            await client.removeLogDestination(dest.name).catch(() => undefined)
+        }
+    } catch (err) {
+        // Roll back — don't persist a binding whose fragment the daemon rejected.
+        if (previous) logBindingRepo.update(previous.id, { enabled: previous.enabled, shaping: previous.shaping, updatedAt: previous.updatedAt })
+        else logBindingRepo.remove(row.id)
+        throw err
+    }
+
+    audit(actor, 'logs.binding.set', `realm:${realmId} → ${dest.name}`, {
+        realm: realmId,
+        destination: dest.name,
+        enabled,
+    })
+    slog('info', 'logs', 'realm log binding set', { realm: realmId, destination: dest.name, enabled, by: actor.login })
+    return toDto(row, dest)
+}
+
+/** Clear a realm binding: retract the daemon fragment (best-effort), then delete the row. */
+export async function removeRealmBinding(actor: LogBindingActor, bindingId: string): Promise<void> {
+    const binding = logBindingRepo.byId(bindingId)
+    if (!binding || binding.scope !== 'realm') {
+        throw new LogBindingError('log binding not found', 'binding_not_found', 404)
+    }
+    const dest = logDestRepo.byId(binding.destinationId)
+    if (dest) {
+        // Best-effort retraction: an unreachable daemon shouldn't strand the row —
+        // reconcileRealm retracts the leftover fragment on its next pass.
+        await realms
+            .clientFor(binding.target)
+            .removeLogDestination(dest.name)
+            .catch((err) => slog('warn', 'logs', 'binding retract failed (reconcile will retry)', { realm: binding.target, error: String(err) }))
+    }
+    logBindingRepo.remove(binding.id)
+    audit(actor, 'logs.binding.delete', `realm:${binding.target} → ${dest?.name ?? binding.destinationId}`)
+    slog('info', 'logs', 'realm log binding removed', { realm: binding.target, destination: dest?.name, by: actor.login })
+}
+
+// ── instance bindings (maintainer; snapshot-delivered — no daemon call) ─────────
+
+/**
+ * Upsert an instance's binding for one destination. Stored only — the change
+ * reaches the client via the agent snapshot's version-hash bump on its next poll.
+ */
+export function setInstanceBinding(
+    actor: LogBindingActor,
+    instanceId: string,
+    input: { destinationId?: unknown; enabled?: unknown; shaping?: unknown },
+): LogBindingDto {
+    if (!instanceRepo.byId(instanceId)) {
+        throw new LogBindingError('instance not found', 'instance_not_found', 404)
+    }
+    const { destinationId, enabled, shaping } = parseBindingInput(input, 'instance')
+    const dest = logDestRepo.byId(destinationId)!
+
+    const now = new Date().toISOString()
+    const previous = logBindingRepo.bySource('instance', instanceId, destinationId)
+    let row: StoredLogBinding
+    if (previous) {
+        logBindingRepo.update(previous.id, { enabled, shaping, updatedAt: now })
+        row = { ...previous, enabled, shaping, updatedAt: now }
+    } else {
+        row = {
+            id: ID.logBinding(),
+            destinationId,
+            scope: 'instance',
+            target: instanceId,
+            enabled,
+            shaping,
+            createdBy: actor.githubId,
+            createdAt: now,
+            updatedAt: now,
+        }
+        logBindingRepo.insert(row)
+    }
+
+    audit(actor, 'logs.binding.set', `instance:${instanceId} → ${dest.name}`, {
+        instance: instanceId,
+        destination: dest.name,
+        enabled,
+    })
+    slog('info', 'logs', 'instance log binding set', { instance: instanceId, destination: dest.name, enabled, by: actor.login })
+    return toDto(row, dest)
+}
+
+/** Patch an instance binding's enabled flag / shaping. */
+export function updateInstanceBinding(
+    actor: LogBindingActor,
+    instanceId: string,
+    bindingId: string,
+    input: { enabled?: unknown; shaping?: unknown },
+): LogBindingDto {
+    const binding = logBindingRepo.byId(bindingId)
+    if (!binding || binding.scope !== 'instance' || binding.target !== instanceId) {
+        throw new LogBindingError('log binding not found', 'binding_not_found', 404)
+    }
+    const dest = logDestRepo.byId(binding.destinationId)
+    if (!dest) throw new LogBindingError('log destination not found', 'destination_not_found', 404)
+
+    let shaping = binding.shaping
+    if (input.shaping !== undefined) {
+        const checked = parseShaping(input.shaping, { scope: 'instance', type: dest.type as DestinationEndpointType })
+        if (!checked.ok) throw new LogBindingError(checked.message, `shaping_${checked.reason}`, 400)
+        shaping = checked.value
+    }
+    const enabled = input.enabled === undefined ? binding.enabled : input.enabled === true
+
+    const now = new Date().toISOString()
+    logBindingRepo.update(binding.id, { enabled, shaping, updatedAt: now })
+    audit(actor, 'logs.binding.set', `instance:${instanceId} → ${dest.name}`, {
+        instance: instanceId,
+        destination: dest.name,
+        enabled,
+    })
+    return toDto({ ...binding, enabled, shaping, updatedAt: now }, dest)
+}
+
+/** Delete an instance binding. Stored only — the snapshot hash bump stops the shipping. */
+export function removeInstanceBinding(actor: LogBindingActor, instanceId: string, bindingId: string): void {
+    const binding = logBindingRepo.byId(bindingId)
+    if (!binding || binding.scope !== 'instance' || binding.target !== instanceId) {
+        throw new LogBindingError('log binding not found', 'binding_not_found', 404)
+    }
+    const dest = logDestRepo.byId(binding.destinationId)
+    logBindingRepo.remove(binding.id)
+    audit(actor, 'logs.binding.delete', `instance:${instanceId} → ${dest?.name ?? binding.destinationId}`)
+    slog('info', 'logs', 'instance log binding removed', { instance: instanceId, destination: dest?.name, by: actor.login })
+}
+
+// ── drift reconcile (G19, per realm) ────────────────────────────────────────────
+
+/**
+ * Drift-reconcile ONE realm's daemon against its own realm bindings: re-push any
+ * enabled binding whose daemon fragment is missing or diverged, retract any daemon
+ * destination Quaykeeper owns the name for but this realm no longer wants (covers
+ * disabled/removed bindings and pre-split strays on non-default realms). A
+ * hand-added daemon destination (name unknown to the DB) is left alone.
+ * Best-effort per destination — one bad target never stalls the pass.
+ */
+export async function reconcileRealm(
+    client: NginxpilotClient,
+    realmId: string,
+): Promise<{ pushed: number; removed: number }> {
+    const desired = new Map<string, LogDestination>()
+    for (const binding of logBindingRepo.listRealm(realmId)) {
+        if (!binding.enabled) continue
+        const dest = logDestRepo.byId(binding.destinationId)
+        if (!dest) continue
+        try {
+            desired.set(dest.name, assembleSpec(dest.spec, binding))
+        } catch (err) {
+            slog('warn', 'logs', 'stored binding failed to assemble — skipped', { name: dest.name, error: String(err) })
+        }
+    }
+
+    const live = await client.listLogDestinations()
+    const liveByName = new Map(live.map((d) => [d.name, d]))
+
+    let pushed = 0
+    for (const [name, spec] of desired) {
+        const current = liveByName.get(name)
+        if (current && sameSpec(current, spec)) continue
+        try {
+            await client.writeLogDestination(spec)
+            pushed++
+        } catch (err) {
+            slog('warn', 'logs', 'drift re-push failed', { name, realm: realmId, error: String(err) })
+        }
+    }
+
+    let removed = 0
+    for (const d of live) {
+        if (desired.has(d.name)) continue
+        if (!logDestRepo.byName(d.name)) continue // not ours (not in DB at all) — leave it
+        try {
+            await client.removeLogDestination(d.name)
+            removed++
+        } catch (err) {
+            slog('warn', 'logs', 'drift retract failed', { name: d.name, realm: realmId, error: String(err) })
+        }
+    }
+    return { pushed, removed }
+}
+
+/** Shallow spec-equality by canonical JSON — good enough to detect drift. */
+function sameSpec(a: LogDestination, b: LogDestination): boolean {
+    return JSON.stringify(canonical(a)) === JSON.stringify(canonical(b))
+}
+
+/** Sort object keys recursively so JSON compare is order-insensitive. */
+function canonical(v: unknown): unknown {
+    if (Array.isArray(v)) return v.map(canonical)
+    if (v && typeof v === 'object') {
+        const out: Record<string, unknown> = {}
+        for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+            out[k] = canonical((v as Record<string, unknown>)[k])
+        }
+        return out
+    }
+    return v
+}
+
+// ── error → HTTP mapping (so routes stay thin) ──────────────────────────────────
+
+export interface HttpError {
+    status: number
+    code: string
+    detail?: string
+}
+
+function sanitizeDetail(raw: string | undefined): string | undefined {
+    if (!raw) return undefined
+    const clean = raw.replace(/[\u0000-\u001f\u007f]+/g, ' ').trim()
+    if (!clean) return undefined
+    return clean.length > 500 ? `${clean.slice(0, 497)}…` : clean
+}
+
+/** Map any error a log-binding op can throw to its HTTP status + code. */
+export function httpErrorFor(err: unknown): HttpError {
+    if (err instanceof LogBindingError) {
+        return { status: err.status, code: err.code, detail: sanitizeDetail(err.message) }
+    }
+    if (err instanceof RealmError) {
+        return { status: err.status, code: err.code }
+    }
+    if (err instanceof NginxpilotError) {
+        switch (err.status) {
+            case 400:
+                return { status: 400, code: 'nginxpilot_rejected', detail: sanitizeDetail(err.detail) }
+            case 404:
+                return { status: 404, code: 'not_found', detail: sanitizeDetail(err.detail) }
+            default:
+                return { status: 502, code: 'nginxpilot_error' }
+        }
+    }
+    return { status: 500, code: 'internal_error' }
+}

--- a/quaykeeper/server/services/log-destinations.ts
+++ b/quaykeeper/server/services/log-destinations.ts
@@ -1,29 +1,28 @@
-// Log-destinations service (log_ides.md §4) — the control plane for structured
-// log shipping. Owner-only (every destination carries a URL, and the `test`
-// endpoint fires outbound HTTP from the edge host → SSRF surface, so per G21 only
-// owners create/edit; site/instance opt-in toggles come later). Unlike routing
-// resources — which live inside nginxpilot — log destinations are stored HERE
-// (`log_destination` table): Quaykeeper owns `scope` and drift-reconciles the
-// daemon's set against these rows (G19).
+// Log-destination service — owner CRUD over reusable log *endpoints*
+// (logs_feature.md §7). Since the endpoint/binding split a destination is only
+// the connection half (name/url/TLS/auth by reference); where it ships from and
+// how the stream is shaped live on `log_binding` rows (services/log-bindings.ts,
+// which also owns every daemon push/retract). Owner-only (every destination
+// carries a URL, and the `test` endpoint fires outbound HTTP from the edge host
+// → SSRF surface, so per G21 only owners create/edit endpoints; maintainers can
+// merely *choose* one when binding an instance, D3).
 //
-// Two scopes ship in v1:
-//   • global   — the shared nginx edge. Rendered to a fragment and pushed to the
-//                active realm's nginxpilot over Channel A (writeLogDestination).
-//   • instance — app-instance logs. Stored only; delivered to quaykeeper-client
-//                via the /v1/config snapshot (services/agent-fetch.ts). nginxpilot
-//                never sees these.
-// (Per-site derived destinations — G18 — are a later addition; the schema's
-// `scope`/`target` columns already anticipate them.)
+// A bare endpoint ships nothing — creating one does NOT touch any daemon. An
+// endpoint update re-pushes every enabled realm binding that references it (the
+// fragments embed endpoint fields); instance bindings refresh implicitly via the
+// agent-snapshot version hash. Deletion is blocked while any binding references
+// the endpoint (409 `destination_in_use`).
 //
-// SECRETS BY REFERENCE ONLY: the reference-only v1 model (§4.1) — a destination's
-// `auth` carries `*_env`/`*_file` names; the operator provisions the actual secret
-// on the nginxpilot host (global) or as an instance variable (instance). Quaykeeper
-// never holds Loki credentials, so there is nothing to encrypt.
+// SECRETS BY REFERENCE ONLY: `auth` carries `*_env`/`*_file` names; the operator
+// provisions the actual secret on the nginxpilot host (realm bindings) or as an
+// instance variable (instance bindings). Quaykeeper never holds credentials.
 
 import 'server-only'
 import * as auditRepo from '@/server/data/repositories/audit-repo'
 import * as logDestRepo from '@/server/data/repositories/log-destination-repo'
-import type { LogDestScope, StoredLogDestination } from '@/server/data/repositories/log-destination-repo'
+import type { StoredLogDestination } from '@/server/data/repositories/log-destination-repo'
+import * as logBindingRepo from '@/server/data/repositories/log-binding-repo'
+import * as realms from '@/server/services/realms'
 import {
     NginxpilotError,
     type LogDestTestResult,
@@ -31,14 +30,14 @@ import {
     type NginxpilotLogsStatus,
 } from '@/server/infrastructure/nginxpilot'
 import {
-    parseLogDestination,
-    logqlSelector,
-    type LogDestination,
+    parseDestinationEndpoint,
+    assembleSpec,
+    type DestinationEndpoint,
 } from '@/server/domain/nginxpilot-logdest-fragment'
 import { ID } from '@/server/infrastructure/ids'
 import { slog } from '@/server/infrastructure/server-log'
 
-/** A refusal Quaykeeper raises *before* touching nginxpilot (bad request shape, name clash, unknown id). */
+/** A refusal Quaykeeper raises *before* touching nginxpilot (bad request shape, name clash, unknown id, in-use delete). */
 export class LogDestError extends Error {
     constructor(
         message: string,
@@ -57,66 +56,45 @@ export interface LogDestActor {
 }
 
 /**
- * A destination as the admin UI sees it: identity + scope + the validated spec
- * (refs only — safe to serialize) + the LogQL selector its labels resolve to (a
- * concrete preview for the label config; empty for non-loki types).
+ * A destination endpoint as the admin UI sees it: identity + the validated
+ * endpoint spec (refs only — safe to serialize) + how many sources bind it (the
+ * at-a-glance reuse signal before editing/deleting, D4).
  */
 export interface LogDestDto {
     id: string
     name: string
     type: string
-    scope: LogDestScope
-    target?: string
-    enabled: boolean
-    spec: LogDestination
-    logql: string
+    spec: DestinationEndpoint
+    usedBy: { realms: number; instances: number }
     createdAt: string
     updatedAt: string
 }
-
-const VALID_SCOPES: ReadonlySet<string> = new Set(['global', 'instance'])
 
 function audit(actor: LogDestActor, action: string, detail: string, meta?: unknown): void {
     auditRepo.append({ githubId: actor.githubId, login: actor.login, action, site: null, detail, meta })
 }
 
 function toDto(row: StoredLogDestination): LogDestDto {
+    const bindings = logBindingRepo.listByDestination(row.id)
     return {
         id: row.id,
         name: row.name,
         type: row.type,
-        scope: row.scope,
-        target: row.target,
-        enabled: row.enabled,
         spec: row.spec,
-        logql: row.type === 'loki' ? logqlSelector(row.spec) : '',
+        usedBy: {
+            realms: bindings.filter((b) => b.scope === 'realm').length,
+            instances: bindings.filter((b) => b.scope === 'instance').length,
+        },
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
     }
 }
 
-/** Validate the request body into a spec plus its scope/target, applying the v1 scope rules. */
-function parseRequest(input: unknown): { spec: LogDestination; scope: LogDestScope; target?: string } {
-    const checked = parseLogDestination(input)
+/** Validate the request body into an endpoint spec. */
+function parseRequest(input: unknown): DestinationEndpoint {
+    const checked = parseDestinationEndpoint(input)
     if (!checked.ok) throw new LogDestError(checked.message, `logdest_${checked.reason}`, 400)
-
-    const o = (input && typeof input === 'object' ? input : {}) as Record<string, unknown>
-    const scopeRaw = typeof o.scope === 'string' && o.scope ? o.scope : 'global'
-    if (!VALID_SCOPES.has(scopeRaw)) {
-        throw new LogDestError('scope must be "global" or "instance"', 'logdest_bad_scope', 400)
-    }
-    const scope = scopeRaw as LogDestScope
-    const target = typeof o.target === 'string' && o.target.trim() ? o.target.trim() : undefined
-    if (scope === 'instance' && !target) {
-        throw new LogDestError('an instance-scoped destination needs a target instance id', 'logdest_target_required', 400)
-    }
-    if (scope === 'instance' && checked.value.type !== 'loki' && checked.value.type !== 'http') {
-        throw new LogDestError('instance destinations must be type loki or http (the client ships over the network)', 'logdest_bad_instance_type', 400)
-    }
-    if (scope !== 'instance' && checked.value.parse?.length) {
-        throw new LogDestError('parse templates apply to instance destinations only (nginxpilot access logs are already JSON)', 'logdest_parse_global', 400)
-    }
-    return { spec: checked.value, scope, target }
+    return checked.value
 }
 
 export function list(): LogDestDto[] {
@@ -129,17 +107,11 @@ export function get(id: string): LogDestDto | undefined {
 }
 
 /**
- * Create a destination. Persists the row, then (global scope) renders + pushes the
- * fragment to the active realm's nginxpilot — the daemon validates the candidate
- * merged config and answers a precise 400 if it disagrees, in which case the row is
- * rolled back so the DB never holds a destination the daemon rejected.
+ * Create a destination endpoint. Persist-only — a bare endpoint ships nothing
+ * until a realm or instance binds it, so no daemon is touched here.
  */
-export async function create(
-    client: NginxpilotClient,
-    actor: LogDestActor,
-    input: unknown,
-): Promise<{ value: LogDestDto; warnings: string[] }> {
-    const { spec, scope, target } = parseRequest(input)
+export function create(actor: LogDestActor, input: unknown): LogDestDto {
+    const spec = parseRequest(input)
     if (logDestRepo.byName(spec.name)) {
         throw new LogDestError(`a log destination named "${spec.name}" already exists`, 'name_taken', 409)
     }
@@ -149,36 +121,27 @@ export async function create(
         id: ID.logDestination(),
         name: spec.name,
         type: spec.type,
-        scope,
-        target,
-        enabled: spec.enabled !== false,
         spec,
         createdBy: actor.githubId,
         createdAt: now,
         updatedAt: now,
     }
     logDestRepo.insert(row)
-
-    let warnings: string[] = []
-    try {
-        if (scope === 'global') {
-            ;({ warnings } = await client.writeLogDestination(spec))
-        }
-    } catch (err) {
-        logDestRepo.remove(row.id) // don't persist a destination the daemon rejected
-        throw err
-    }
-    audit(actor, 'logs.destination.create', `${spec.name} (${spec.type}, ${scope})`, redactMeta(row))
-    slog('info', 'logs', 'log destination created', { name: spec.name, type: spec.type, scope, by: actor.login })
-    return { value: toDto(row), warnings }
+    audit(actor, 'logs.destination.create', `${spec.name} (${spec.type})`, { name: spec.name, type: spec.type })
+    slog('info', 'logs', 'log destination created', { name: spec.name, type: spec.type, by: actor.login })
+    return toDto(row)
 }
 
 /**
- * Replace a destination (name is immutable — it is the fragment key). If the name in
- * the body differs from the stored name it is rejected; delete and recreate to rename.
+ * Replace a destination endpoint (name is immutable — it is the fragment key; delete
+ * and recreate to rename). The daemon fragments embed endpoint fields, so every
+ * enabled realm binding referencing this endpoint is re-pushed to *its* realm
+ * (`clientFor(binding.target)`); a per-realm push failure is folded into `warnings`
+ * (the reconcile pass retries it) rather than failing the update. Instance bindings
+ * refresh implicitly — the agent snapshot reads the endpoint fresh, so the version
+ * hash bumps and every bound client hot-reloads on its next poll.
  */
 export async function update(
-    client: NginxpilotClient,
     actor: LogDestActor,
     id: string,
     input: unknown,
@@ -186,41 +149,52 @@ export async function update(
     const existing = logDestRepo.byId(id)
     if (!existing) throw new LogDestError('log destination not found', 'not_found', 404)
 
-    const { spec, scope, target } = parseRequest(input)
+    const spec = parseRequest(input)
     if (spec.name !== existing.name) {
         throw new LogDestError('a destination name is immutable (delete and recreate to rename)', 'name_immutable', 400)
     }
 
     const now = new Date().toISOString()
-    const next: StoredLogDestination = {
-        ...existing,
-        type: spec.type,
-        scope,
-        target,
-        enabled: spec.enabled !== false,
-        spec,
-        updatedAt: now,
+    logDestRepo.update(id, { type: spec.type, spec, updatedAt: now })
+
+    const warnings: string[] = []
+    for (const binding of logBindingRepo.listByDestination(id)) {
+        if (binding.scope !== 'realm' || !binding.enabled) continue
+        try {
+            const client = realms.clientFor(binding.target)
+            const { warnings: pushWarnings } = await client.writeLogDestination(assembleSpec(spec, binding))
+            warnings.push(...pushWarnings)
+        } catch (err) {
+            slog('warn', 'logs', 'endpoint-update fragment re-push failed', {
+                name: spec.name,
+                realm: binding.target,
+                error: String(err),
+            })
+            warnings.push(`fragment re-push failed for realm ${binding.target} — the reconcile pass will retry`)
+        }
     }
 
-    let warnings: string[] = []
-    if (scope === 'global') {
-        ;({ warnings } = await client.writeLogDestination(spec))
-    } else if (existing.scope === 'global') {
-        // Scope moved off the edge — retract the daemon fragment.
-        await client.removeLogDestination(existing.name).catch(() => undefined)
-    }
-    logDestRepo.update(id, { type: next.type, scope, target: target ?? null, enabled: next.enabled, spec, updatedAt: now })
-    audit(actor, 'logs.destination.update', `${spec.name} (${spec.type}, ${scope})`, redactMeta(next))
-    slog('info', 'logs', 'log destination updated', { name: spec.name, scope, by: actor.login })
-    return { value: toDto(next), warnings }
+    audit(actor, 'logs.destination.update', `${spec.name} (${spec.type})`, { name: spec.name, type: spec.type })
+    slog('info', 'logs', 'log destination updated', { name: spec.name, by: actor.login })
+    const next = logDestRepo.byId(id)
+    return { value: toDto(next ?? { ...existing, type: spec.type, spec, updatedAt: now }), warnings }
 }
 
-/** Delete a destination from the DB and (global scope) retract its daemon fragment. */
-export async function remove(client: NginxpilotClient, actor: LogDestActor, id: string): Promise<void> {
+/**
+ * Delete a destination endpoint. Blocked (409 `destination_in_use`) while any
+ * binding references it — unbind from the Servers page / instance Logs tab first.
+ * An unbound endpoint has no daemon fragment anywhere, so this is DB-only.
+ */
+export function remove(actor: LogDestActor, id: string): void {
     const existing = logDestRepo.byId(id)
     if (!existing) throw new LogDestError('log destination not found', 'not_found', 404)
-    if (existing.scope === 'global') {
-        await client.removeLogDestination(existing.name)
+    const inUse = logBindingRepo.countByDestination(id)
+    if (inUse > 0) {
+        throw new LogDestError(
+            `"${existing.name}" is in use by ${inUse} binding(s) — unbind first`,
+            'destination_in_use',
+            409,
+        )
     }
     logDestRepo.remove(id)
     audit(actor, 'logs.destination.delete', existing.name)
@@ -228,83 +202,19 @@ export async function remove(client: NginxpilotClient, actor: LogDestActor, id: 
 }
 
 /**
- * Test a CANDIDATE destination (body-based, pre-save) against the active realm's
- * daemon — validate it, push one synthetic entry, report the outcome. Owner-only and
- * never persisted; the URL SSRF surface is why this is gated to owners (G21).
+ * Test a CANDIDATE endpoint (body-based, pre-save) against the active realm's
+ * daemon — assemble it with empty shaping, push one synthetic entry, report the
+ * outcome. Owner-only and never persisted; the URL SSRF surface is why this is
+ * gated to owners (G21).
  */
 export async function test(client: NginxpilotClient, input: unknown): Promise<LogDestTestResult> {
-    const { spec } = parseRequest(input)
-    return client.testLogDestination(spec)
+    const spec = parseRequest(input)
+    return client.testLogDestination(assembleSpec(spec, { scope: 'realm', enabled: true, shaping: {} }))
 }
 
-/** Per-destination shipping stats + intake health from the active realm (`GET /logs/status`). */
+/** Per-destination shipping stats + intake health from one realm's daemon (`GET /logs/status`). */
 export async function logsStatus(client: NginxpilotClient): Promise<NginxpilotLogsStatus> {
     return client.logsStatus()
-}
-
-/**
- * Drift-reconcile the active realm's daemon against the DB's global destinations
- * (G19): re-push any global row whose daemon copy is missing or diverged, and retract
- * any daemon destination Quaykeeper no longer owns. Best-effort — a per-destination
- * failure is logged and skipped so one bad target never stalls the pass. Returns a
- * small summary for the caller (status-poll) to log.
- */
-export async function reconcile(client: NginxpilotClient): Promise<{ pushed: number; removed: number }> {
-    const desired = logDestRepo.listByScope('global')
-    const live = await client.listLogDestinations()
-    const liveByName = new Map(live.map((d) => [d.name, d]))
-    const desiredNames = new Set(desired.map((d) => d.name))
-
-    let pushed = 0
-    for (const row of desired) {
-        const current = liveByName.get(row.name)
-        if (current && sameSpec(current, row.spec)) continue
-        try {
-            await client.writeLogDestination(row.spec)
-            pushed++
-        } catch (err) {
-            slog('warn', 'logs', 'drift re-push failed', { name: row.name, error: String(err) })
-        }
-    }
-
-    // Retract daemon destinations Quaykeeper owns the namespace for but no longer wants.
-    // Only remove names that look Quaykeeper-managed AND aren't in the desired set; a
-    // hand-added daemon destination (unknown to the DB) is left alone.
-    let removed = 0
-    for (const d of live) {
-        if (desiredNames.has(d.name)) continue
-        if (!logDestRepo.byName(d.name)) continue // not ours (not in DB at all) — leave it
-        try {
-            await client.removeLogDestination(d.name)
-            removed++
-        } catch (err) {
-            slog('warn', 'logs', 'drift retract failed', { name: d.name, error: String(err) })
-        }
-    }
-    return { pushed, removed }
-}
-
-/** Shallow spec-equality by canonical JSON — good enough to detect drift. */
-function sameSpec(a: LogDestination, b: LogDestination): boolean {
-    return JSON.stringify(canonical(a)) === JSON.stringify(canonical(b))
-}
-
-/** Sort object keys recursively so JSON compare is order-insensitive. */
-function canonical(v: unknown): unknown {
-    if (Array.isArray(v)) return v.map(canonical)
-    if (v && typeof v === 'object') {
-        const out: Record<string, unknown> = {}
-        for (const k of Object.keys(v as Record<string, unknown>).sort()) {
-            out[k] = canonical((v as Record<string, unknown>)[k])
-        }
-        return out
-    }
-    return v
-}
-
-/** Audit meta never carries anything sensitive (spec is refs only), but stamp scope/target explicitly. */
-function redactMeta(row: StoredLogDestination): unknown {
-    return { name: row.name, type: row.type, scope: row.scope, target: row.target, enabled: row.enabled }
 }
 
 // ── error → HTTP mapping (so routes stay thin) ──────────────────────────────────

--- a/quaykeeper/server/services/realms.ts
+++ b/quaykeeper/server/services/realms.ts
@@ -21,6 +21,7 @@ import * as realmRepo from '@/server/data/repositories/realm-repo'
 import * as userRealmRepo from '@/server/data/repositories/user-realm-repo'
 import * as siteRepo from '@/server/data/repositories/site-repo'
 import * as baseDomainRepo from '@/server/data/repositories/base-domain-repo'
+import * as logBindingRepo from '@/server/data/repositories/log-binding-repo'
 import * as userRepo from '@/server/data/repositories/user-repo'
 import * as auditRepo from '@/server/data/repositories/audit-repo'
 import { tx } from '@/server/data/db'
@@ -451,6 +452,10 @@ export function removeRealm(actor: RealmActor, id: string): void {
         )
     }
 
+    // Log bindings cascade rather than block (D5, unlike the sites/base-domains
+    // guards above): the daemon and its fragments die with the realm, so no
+    // removeLogDestination call is needed — just drop the rows.
+    logBindingRepo.removeByTarget('realm', id)
     realmRepo.remove(id)
     audit(actor, 'admin.realm.remove', r.name)
     slog('info', 'realms', 'realm removed', { id, name: r.name, by: actor.login })

--- a/quaykeeper/server/services/status-poll.ts
+++ b/quaykeeper/server/services/status-poll.ts
@@ -17,7 +17,7 @@ import * as realmRepo from '@/server/data/repositories/realm-repo'
 import * as stateRepo from '@/server/data/repositories/resource-state-repo'
 import * as auditRepo from '@/server/data/repositories/audit-repo'
 import * as realms from '@/server/services/realms'
-import * as logDests from '@/server/services/log-destinations'
+import * as logBindings from '@/server/services/log-bindings'
 import { diffEpisodes, type LiveBadState } from '@/server/domain/resource-state'
 import { tx } from '@/server/data/db'
 import { slog } from '@/server/infrastructure/server-log'
@@ -124,12 +124,12 @@ export async function pollNow(): Promise<{ realms: number; opened: number; close
             slog('warn', 'status-poll', 'realm poll failed', { realm: realm.id, error: String(err) })
         }
 
-        // Log-destination drift reconciliation (G19): re-push global destinations
-        // whose daemon copy is missing or diverged (a redeployed daemon with a wiped
-        // conf dir, a hand-deleted fragment). Separate best-effort block so a shipping
-        // target being unreachable never affects resource-state episodes above.
+        // Log-destination drift reconciliation (G19): re-push this realm's bound
+        // destinations whose daemon copy is missing or diverged (a redeployed daemon
+        // with a wiped conf dir, a hand-deleted fragment). Separate best-effort block
+        // so a shipping target being unreachable never affects resource-state episodes.
         try {
-            const { pushed, removed } = await logDests.reconcile(realms.clientFor(realm.id))
+            const { pushed, removed } = await logBindings.reconcileRealm(realms.clientFor(realm.id), realm.id)
             if (pushed || removed) {
                 slog('info', 'status-poll', 'log destinations reconciled', { realm: realm.id, pushed, removed })
             }


### PR DESCRIPTION
Rework the monolithic log-destination model (logs_feature.md) — the nginxpilot and client-go wire contract is unchanged; only quaykeeper's storage, services, routes, and UI change:

- domain: extract shared endpoint/tunables validation; add DestinationEndpoint, LogShaping, parseShaping, and assembleSpec(dest, binding), which reassembles the two halves into the existing LogDestination wire shape
- data: new log_binding table (UNIQUE(scope, target, destination_id)); log_destination repurposed as an endpoint-only registry (loki/http, no scope/target/shaping); new log-binding-repo + ID.logBinding
- services: new log-bindings service owns daemon push/retract — realm bindings push to their own realm's client (never the active-realm cookie) with rollback on daemon reject; instance bindings are snapshot-delivered; per-realm reconcileRealm replaces the global reconcile; endpoint update re-pushes bound realms; delete blocked with 409 while bound; realm delete cascade-drops its bindings
- api: realm binding routes (owner) + instance logs routes (maintainer, D3); status route accepts ?realm= for per-daemon stats
- ui: endpoint-only /admin/log-destinations with "Used by" counts; RealmLogDestModal + logs badge on the Servers page; new Logs tab under /instances/[id] with shared shaping form; "Variables" section renamed to "Instances"
- db: squash migrations v1–v21 into a single v1 creating the final schema (fresh-database semantics; deprecated log_destination scope/target/enabled columns dropped outright); migration runner now accepts function entries for future TS backfills

<!--
Thanks for the PR! Please fill out the sections below so reviewers can move quickly.
For first-time contributors: read CONTRIBUTING.md for repo conventions.
-->

## Summary

<!-- One or two sentences. What does this PR change and why? -->

## Affected packages

<!-- Tick all that apply. Delete the rest. -->

- [ ] `@toolcase/base`
- [ ] `@toolcase/logging`
- [ ] `@toolcase/serializer`
- [ ] `@toolcase/node`
- [ ] `@toolcase/web-components`
- [ ] `@toolcase/phaser-plus`
- [ ] `examples/` site
- [ ] Repo / CI / tooling

## Change type

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (API removal, behavior change)
- [ ] Refactor / internal cleanup
- [ ] Docs / SKILL.md / examples
- [ ] Build / CI / tooling

## Test plan

<!-- How did you verify the change? Be specific. -->

- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `npm run lint:exports` (when public surface changes)
- [ ] Manual check in `examples/` (when UI changes)

## Checklist

- [ ] PR is focused on a single logical change
- [ ] Public API changes are reflected in the relevant `examples/public/<pkg>/SKILL.md`
- [ ] New component / export is added to its package's `src/index.ts`
- [ ] No `border-radius` introduced in `web-components` (except sanctioned circles/pills)
- [ ] New `web-components` entries register their tag in `src/register.ts` and clean up listeners/observers in `disconnectedCallback`

## Related issues

<!-- e.g. Closes #123, Refs #456 -->
